### PR TITLE
Adding remote query for counts in bins

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,10 @@ add_library(cpg_index OBJECT
   cpg_index.hpp
   cpg_index.cpp)
 
+add_library(cpg_index_set OBJECT
+  cpg_index_set.hpp
+  cpg_index_set.cpp)
+
 add_library(genomic_interval OBJECT
   genomic_interval.hpp
   genomic_interval.cpp)
@@ -126,6 +130,7 @@ target_link_libraries(
   bins
   genomic_interval
   cpg_index
+  cpg_index_set
   methylome
   methylome_set
   server

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,30 +24,50 @@
 # $ cmake --version
 cmake_minimum_required(VERSION 3.30)
 
-add_library(utilities OBJECT
-  utilities.hpp
-  utilities.cpp)
-
-add_library(lookup OBJECT
-  lookup.hpp
-  lookup.cpp)
-
-add_library(logger OBJECT
-  logger.hpp
-  logger.cpp)
-
-add_library(bins OBJECT
-  bins.hpp
-  bins.cpp)
-
-add_library(zip OBJECT
-  zip.hpp
-  zip.cpp)
+add_library(methylome OBJECT
+  methylome.hpp
+  methylome.cpp)
 
 add_library(methylome_metadata OBJECT
   methylome_metadata.hpp
   methylome_metadata.cpp)
 target_include_directories(methylome_metadata PRIVATE "${PROJECT_BINARY_DIR}")
+
+add_library(methylome_set OBJECT
+  methylome_set.hpp
+  methylome_set.cpp)
+
+add_library(cpg_index OBJECT
+  cpg_index.hpp
+  cpg_index.cpp)
+
+add_library(cpg_index_set OBJECT
+  cpg_index_set.hpp
+  cpg_index_set.cpp)
+
+add_library(genomic_interval OBJECT
+  genomic_interval.hpp
+  genomic_interval.cpp)
+
+add_library(logger OBJECT
+  logger.hpp
+  logger.cpp)
+
+add_library(utilities OBJECT
+  utilities.hpp
+  utilities.cpp)
+
+add_library(zip OBJECT
+  zip.hpp
+  zip.cpp)
+
+add_library(lookup OBJECT
+  lookup.hpp
+  lookup.cpp)
+
+add_library(bins OBJECT
+  bins.hpp
+  bins.cpp)
 
 add_library(compress OBJECT
   compress.hpp
@@ -80,26 +100,6 @@ add_library(connection OBJECT
 add_library(request_handler OBJECT
   request_handler.hpp
   request_handler.cpp)
-
-add_library(methylome OBJECT
-  methylome.hpp
-  methylome.cpp)
-
-add_library(methylome_set OBJECT
-  methylome_set.hpp
-  methylome_set.cpp)
-
-add_library(cpg_index OBJECT
-  cpg_index.hpp
-  cpg_index.cpp)
-
-add_library(cpg_index_set OBJECT
-  cpg_index_set.hpp
-  cpg_index_set.cpp)
-
-add_library(genomic_interval OBJECT
-  genomic_interval.hpp
-  genomic_interval.cpp)
 
 add_library(response OBJECT
   response.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,11 +44,14 @@ add_library(zip OBJECT
   zip.hpp
   zip.cpp)
 
+add_library(methylome_metadata OBJECT
+  methylome_metadata.hpp
+  methylome_metadata.cpp)
+target_include_directories(methylome_metadata PRIVATE "${PROJECT_BINARY_DIR}")
+
 add_library(compress OBJECT
   compress.hpp
   compress.cpp)
-
-target_include_directories(compress PRIVATE "${PROJECT_BINARY_DIR}")
 
 add_library(check OBJECT
   check.hpp
@@ -132,6 +135,7 @@ target_link_libraries(
   cpg_index
   cpg_index_set
   methylome
+  methylome_metadata
   methylome_set
   server
   connection

--- a/src/automatic_json.hpp
+++ b/src/automatic_json.hpp
@@ -1,0 +1,49 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// ADS: this was copied directly from the example in the docs for
+// the boost::describe library
+
+#ifndef SRC_AUTOMATIC_JSON_HPP_
+#define SRC_AUTOMATIC_JSON_HPP_
+
+#include <boost/describe.hpp>
+#include <boost/json/src.hpp>
+#include <boost/mp11.hpp>
+
+template <
+  class T,
+  class D1 = boost::describe::describe_members<
+    T, boost::describe::mod_public | boost::describe::mod_protected>,
+  class D2 = boost::describe::describe_members<T, boost::describe::mod_private>,
+  class En = std::enable_if_t<boost::mp11::mp_empty<D2>::value &&
+                              !std::is_union<T>::value>>
+auto
+tag_invoke(const boost::json::value_from_tag &, boost::json::value &v,
+           const T &t) {
+  auto &obj = v.emplace_object();
+  boost::mp11::mp_for_each<D1>(
+    [&](const auto D) { obj[D.name] = boost::json::value_from(t.*D.pointer); });
+}
+
+#endif  // SRC_AUTOMATIC_JSON_HPP_

--- a/src/bins.cpp
+++ b/src/bins.cpp
@@ -24,122 +24,223 @@
 #include "bins.hpp"
 #include "cpg_index.hpp"
 #include "genomic_interval.hpp"
+#include "logger.hpp"
 #include "methylome.hpp"
 #include "mxe_error.hpp"
 #include "utilities.hpp"
 
 #include <boost/program_options.hpp>
 
-#include <algorithm>
-#include <array>
 #include <chrono>
 #include <cstdint>
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <print>
-#include <ranges>
 #include <string>
 #include <tuple>
 #include <vector>
 
-using std::array;
-using std::cbegin;
-using std::cend;
-using std::cerr;
-using std::cout;
-using std::min;
 using std::ofstream;
-using std::print;
-using std::println;
 using std::string;
 using std::tuple;
-using std::uint32_t;
 using std::vector;
 
-namespace rg = std::ranges;
-namespace vs = std::views;
-using hr_clock = std::chrono::high_resolution_clock;
+template <typename counts_res_type>
+[[nodiscard]] static inline auto
+do_local_bins(const string &meth_file, const cpg_index &index,
+              const std::uint32_t bin_size)
+  -> tuple<vector<counts_res_type>, std::error_code> {
+  methylome meth{};
+  if (const auto meth_read_err = meth.read(meth_file, index.n_cpgs_total)) {
+    logger::instance().error("Error: {} ({})", meth_read_err, meth_file);
+    return {{}, meth_read_err};
+  }
+  if constexpr (std::is_same<counts_res_type, counts_res_cov>::value)
+    return {std::move(meth.get_bins_cov(bin_size, index)), {}};
+  else
+    return {std::move(meth.get_bins(bin_size, index)), {}};
+}
 
-namespace po = boost::program_options;
-using po::value;
+template <typename counts_res_type>
+static auto
+do_bins(const string &accession, const cpg_index &index,
+        const std::uint32_t bin_size, const string &hostname,
+        const string &port, const string &meth_file, std::ostream &out,
+        const bool write_scores, [[maybe_unused]] const bool remote_mode)
+  -> std::error_code {
+
+  using hr_clock = std::chrono::high_resolution_clock;
+
+  const auto bins_start{hr_clock::now()};
+  const auto [results, bins_err] =
+    do_local_bins<counts_res_type>(meth_file, index, bin_size);
+  const auto bins_stop{hr_clock::now()};
+  logger::instance().debug("Elapsed time for bins query: {:.3}s",
+                           duration(bins_start, bins_stop));
+
+  if (bins_err)  // ADS: error messages already logged
+    return std::make_error_code(std::errc::invalid_argument);
+
+  const auto output_start{hr_clock::now()};
+  write_bins(out, bin_size, index, results);
+  const auto output_stop{hr_clock::now()};
+  // ADS: elapsed time for output will include conversion to scores
+  logger::instance().debug("Elapsed time for output: {:.3}s",
+                           duration(output_start, output_stop));
+  return {};
+}
 
 auto
 bins_main(int argc, char *argv[]) -> int {
-  static const auto description = std::format("{}", "bins");
+  static constexpr auto usage_format =
+    "Usage: mxe lookup {} [options]\n\nOption groups";
+  static constexpr mxe_log_level default_log_level = mxe_log_level::info;
+  static constexpr auto default_port = "5000";
+  static const auto command = "bins";
 
-  bool verbose{};
+  bool count_covered{};
+  bool write_scores{};
 
   string index_file{};
   string meth_file{};
-  string output_file{};
+  string outfile{};
+  std::uint32_t bin_size{};
+  mxe_log_level log_level{};
+  string hostname{};
+  string port{};
+  string accession{};
 
-  uint32_t bin_size{};
+  string subcmd;
 
-  po::options_description desc(description);
+  namespace po = boost::program_options;
+
+  po::options_description subcmds;
+  subcmds.add_options()
+    // clang-format off
+    ("subcmd", po::value(&subcmd))
+    ("subargs", po::value<vector<string>>())
+    // clang-format on
+    ;
+  // positional; one for "subcmd" and the rest else parser throws
+  po::positional_options_description p;
+  p.add("subcmd", 1).add("subargs", -1);
+
+  po::variables_map vm_subcmd;
+  po::store(po::command_line_parser(argc, argv)
+              .options(subcmds)
+              .positional(p)
+              .allow_unregistered()
+              .run(),
+            vm_subcmd);
+  po::notify(vm_subcmd);
+
+  if (subcmd != "local" && subcmd != "remote") {
+    std::println("Usage: mxe lookup [local|remote] [options]");
+    return EXIT_FAILURE;
+  }
+  const bool remote_mode = subcmd == "remote";
+
+  po::options_description general("General");
   // clang-format off
-  desc.add_options()
+  general.add_options()
     ("help,h", "produce help message")
-    ("index,x", value(&index_file)->required(), "index file")
-    ("bin,b", value(&bin_size)->required(), "size of bins")
-    ("meth,m", value(&meth_file)->required(), "methylation file")
-    ("output,o", value(&output_file)->required(), "output file")
-    ("verbose,v", po::bool_switch(&verbose), "print more run info")
+    ("index,x", po::value(&index_file)->required(), "index file")
+    ("bin-size,b", po::value(&bin_size)->required(), "size of bins")
+    ("log-level,v", po::value(&log_level)->default_value(default_log_level),
+     "log level {debug,info,warning,error,critical}")
+    ;
+  po::options_description output("Output");
+  output.add_options()
+    ("output,o", po::value(&outfile)->required(), "output file")
+    ("covered", po::bool_switch(&count_covered), "count covered sites per bin")
+    ("score", po::bool_switch(&write_scores), "weighted methylation bedgraph format")
+    ;
+  po::options_description remote("Remote");
+  remote.add_options()
+    ("hostname,s", po::value(&hostname)->required(), "server hostname")
+    ("port,p", po::value(&port)->default_value(default_port), "port")
+    ("accession,a", po::value(&accession)->required(), "methylome accession")
+    ;
+  po::options_description local("Local");
+  local.add_options()
+    ("methylome,m", po::value(&meth_file)->required(), "local methylome file")
     ;
   // clang-format on
+
+  po::options_description all(std::format(usage_format, subcmd));
+  all.add(general).add(output);
+  all.add(remote_mode ? remote : local);
+
   try {
     po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::store(po::parse_command_line(argc - 1, argv + 1, all), vm);
     if (vm.count("help")) {
-      desc.print(std::cout);
+      all.print(std::cout);
       return EXIT_SUCCESS;
     }
     po::notify(vm);
   }
   catch (po::error &e) {
-    println(cerr, "{}", e.what());
-    desc.print(std::cout);
+    std::println("{}", e.what());
+    all.print(std::cout);
     return EXIT_FAILURE;
   }
 
-  if (verbose)
-    print("index: {}\n"
-          "methylome: {}\n"
-          "output: {}\n"
-          "bin_size: {}\n",
-          index_file, meth_file, output_file, bin_size);
+  logger &lgr = logger::instance(
+    std::make_shared<std::ostream>(std::cout.rdbuf()), command, log_level);
+  if (!lgr) {
+    std::println("Failure initializing logging: {}.", lgr.get_status());
+    return EXIT_FAILURE;
+  }
+
+  // ADS: log the command line arguments (assuming right log level)
+  vector<tuple<string, string>> args_to_log{
+    {"Index", index_file},
+    {"Binsize", std::format("{}", bin_size)},
+    {"Output", outfile},
+    {"Covered", std::format("{}", count_covered)},
+    {"Bedgraph", std::format("{}", write_scores)},
+  };
+  vector<tuple<string, string>> remote_args{
+    {"Hostname:port", std::format("{}:{}", hostname, port)},
+    {"Accession", accession},
+  };
+  vector<tuple<string, string>> local_args{
+    {"Methylome", meth_file},
+  };
+  log_args<mxe_log_level::info>(args_to_log);
+  log_args<mxe_log_level::info>(remote_mode ? remote_args : local_args);
 
   cpg_index index{};
   if (const auto index_read_err = index.read(index_file); index_read_err) {
-    println(cerr, "Error: {} ({})", index_read_err, index_file);
+    lgr.error("Failed to read cpg index: {} ({})", index_file, index_read_err);
     return EXIT_FAILURE;
   }
 
-  if (verbose)
-    println("index:\n{}", index);
+  if (log_level == mxe_log_level::debug)
+    lgr.debug("Number of CpGs in index: {}", index.n_cpgs_total);
 
   methylome meth{};
   const auto meth_read_err = meth.read(meth_file, index.n_cpgs_total);
   if (meth_read_err) {
-    println(cerr, "Failed to read methylome: {}", meth_read_err);
+    lgr.error("Failed to read methylome: {}", meth_read_err);
     return EXIT_FAILURE;
   }
 
-  ofstream out(output_file);
+  ofstream out(outfile);
   if (!out) {
-    println(cerr, "Failed to open output file: {}", output_file);
+    lgr.error("Failed to open output file: {}", outfile);
     return EXIT_FAILURE;
   }
 
-  const auto get_bins_start{hr_clock::now()};
-  const auto results = meth.get_bins_cov(bin_size, index);
-  const auto get_bins_stop{hr_clock::now()};
+  const auto bins_err =
+    count_covered
+      ? do_bins<counts_res_cov>(accession, index, bin_size, hostname, port,
+                                meth_file, out, write_scores, remote_mode)
+      : do_bins<counts_res>(accession, index, bin_size, hostname, port,
+                            meth_file, out, write_scores, remote_mode);
 
-  if (verbose)
-    println("Elapsed time to get bins: {:.3}s",
-            duration(get_bins_start, get_bins_stop));
-
-  write_bins(out, bin_size, index, results);
-
-  return EXIT_SUCCESS;
+  return bins_err == std::errc() ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -90,7 +90,7 @@ check_main(int argc, char *argv[]) -> int {
   }
 
   if (metadata_input.empty())
-    metadata_input = std::format("{}.json", methylome_input);
+    metadata_input = get_default_methylome_metadata_filename(methylome_input);
 
   std::vector<std::tuple<std::string, std::string>> args_to_log{
     // clang-format off

--- a/src/check.cpp
+++ b/src/check.cpp
@@ -49,8 +49,8 @@ check_main(int argc, char *argv[]) -> int {
   static constexpr auto command = "check";
 
   std::string index_file{};
-  std::string meth_file{};
-  std::string meth_meta_file{};
+  std::string methylome_input{};
+  std::string metadata_input{};
   std::string output_file{};
   mxe_log_level log_level{};
 
@@ -61,8 +61,8 @@ check_main(int argc, char *argv[]) -> int {
     // clang-format off
     ("help,h", "produce help message")
     ("index,x", po::value(&index_file)->required(), "index file")
-    ("methylome,m", po::value(&meth_file)->required(), "methylome file")
-    ("meta", po::value(&meth_meta_file), "methylome metadata file")
+    ("methylome,m", po::value(&methylome_input)->required(), "methylome file")
+    ("meta", po::value(&metadata_input), "methylome metadata file")
     ("output,o", po::value(&output_file)->required(), "output file")
     ("log-level,v", po::value(&log_level)->default_value(default_log_level),
      "log level {debug,info,warning,error,critical}")
@@ -89,11 +89,14 @@ check_main(int argc, char *argv[]) -> int {
     return EXIT_FAILURE;
   }
 
+  if (metadata_input.empty())
+    metadata_input = std::format("{}.json", methylome_input);
+
   std::vector<std::tuple<std::string, std::string>> args_to_log{
     // clang-format off
     {"Index", index_file},
-    {"Methylome", meth_file},
-    {"Metadata", meth_meta_file},
+    {"Methylome", methylome_input},
+    {"Metadata", metadata_input},
     {"Output", output_file},
     // clang-format on
   };
@@ -105,16 +108,16 @@ check_main(int argc, char *argv[]) -> int {
     return EXIT_FAILURE;
   }
 
-  const auto [meta, meta_read_err] = methylome_metadata::read(meth_meta_file);
+  const auto [meta, meta_read_err] = methylome_metadata::read(metadata_input);
   if (meta_read_err) {
-    lgr.error("Error reading metadata {}: {}", meth_meta_file, meta_read_err);
+    lgr.error("Error reading metadata {}: {}", metadata_input, meta_read_err);
     return EXIT_FAILURE;
   }
 
   methylome meth{};
-  const auto meth_read_err = meth.read(meth_file, meta);
+  const auto meth_read_err = meth.read(methylome_input, meta);
   if (meth_read_err) {
-    lgr.error("Error reading methylome {}: {}", meth_file, meth_read_err);
+    lgr.error("Error reading methylome {}: {}", methylome_input, meth_read_err);
     return EXIT_FAILURE;
   }
 

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -42,19 +42,16 @@ public:
   mxe_client(const std::string &server, const std::string &port,
              request_header &req_hdr, req_type &req, logger &lgr);
 
-  auto
-  run() -> std::error_code {
+  auto run() -> std::error_code {
     io_context.run();
     return status;
   }
 
-  auto
-  get_counts() const -> const std::vector<counts_type> & {
+  auto get_counts() const -> const std::vector<counts_type> & {
     return resp.counts;
   }
 
-  auto
-  take_counts() -> std::vector<counts_type> {
+  auto take_counts() -> std::vector<counts_type> {
     // ADS: this function resets resp.counts and avoids copy
     std::vector<counts_type> moved_out;
     std::swap(moved_out, resp.counts);
@@ -65,20 +62,13 @@ private:
   auto
   handle_resolve(const std::error_code &err,
                  const boost::asio::ip::tcp::resolver::results_type &endpoints);
-  auto
-  handle_connect(const std::error_code &err);
-  auto
-  handle_write_request(const std::error_code &err);
-  auto
-  handle_read_response_header(const std::error_code &err);
-  auto
-  do_read_counts();
-  auto
-  handle_failure_explanation(const std::error_code &err);
-  auto
-  do_finish(const std::error_code &err);
-  auto
-  check_deadline();
+  auto handle_connect(const std::error_code &err);
+  auto handle_write_request(const std::error_code &err);
+  auto handle_read_response_header(const std::error_code &err);
+  auto do_read_counts();
+  auto handle_failure_explanation(const std::error_code &err);
+  auto do_finish(const std::error_code &err);
+  auto check_deadline();
 
   boost::asio::io_context io_context;
   boost::asio::ip::tcp::resolver resolver;

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -26,7 +26,6 @@
 
 #include "logger.hpp"
 #include "request.hpp"
-#include "request_handler.hpp"
 #include "response.hpp"
 
 #include <boost/asio.hpp>
@@ -94,8 +93,9 @@ mxe_client<counts_type>::mxe_client(const std::string &server,
                                     const std::string &port,
                                     request_header &req_hdr, request &req,
                                     logger &lgr) :
-  resolver(io_context), socket(io_context), deadline{socket.get_executor()},
-  req_hdr{req_hdr}, req{std::move(req)},  // move b/c req can be big
+  resolver(io_context),
+  socket(io_context), deadline{socket.get_executor()}, req_hdr{req_hdr},
+  req{std::move(req)},  // move b/c req can be big
   lgr{lgr} {
   // (1) call async, (2) set deadline, (3) register check_deadline
   const auto handle_resolve_token = [this](const auto &error, auto results) {

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -273,7 +273,9 @@ process_cpg_sites(const std::string &infile, const std::string &outfile,
   cpg_idx_out += add_all_cpgs(prev_ch_id, size(index.positions), index);
 
   if (cpg_idx_out != index.n_cpgs_total) {
-    std::println("Failed to generate mxe methylome");
+    logger::instance().error(
+      "Inconsistent numbers of cpgs (index={}, processed={})",
+      index.n_cpgs_total, cpg_idx_out);
     return compress_err::methylome_compression_failure;
   }
 
@@ -281,7 +283,8 @@ process_cpg_sites(const std::string &infile, const std::string &outfile,
   m.cpgs = std::move(cpgs);
   const auto meth_write_err = m.write(outfile, zip);
   if (meth_write_err) {
-    std::println("Error: {} ({})", meth_write_err, outfile);
+    logger::instance().error("Error writing methylome {}: {}", outfile,
+                             meth_write_err);
     return compress_err::methylome_file_write_failure;
   }
 

--- a/src/compress.cpp
+++ b/src/compress.cpp
@@ -22,96 +22,37 @@
  */
 
 #include "compress.hpp"
+
 #include "cpg_index.hpp"
 #include "genomic_interval.hpp"
+#include "logger.hpp"
 #include "methylome.hpp"
+#include "methylome_metadata.hpp"
 #include "mxe_error.hpp"
 #include "utilities.hpp"
 
-#include <config.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <zlib.h>
 
-#include <boost/asio.hpp>  // boost::asio::ip::host_name();
 #include <boost/program_options.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cassert>
 #include <charconv>
-#include <chrono>
-#include <filesystem>
 #include <iostream>
 #include <limits>
 #include <numeric>
 #include <print>
 #include <string>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
-using std::from_chars;
-using std::max;
-using std::pair;
 using std::println;
 using std::size;
 using std::string;
-using std::unordered_map;
-using std::vector;
-
-namespace po = boost::program_options;
-using po::value;
-
-template <typename T> using num_lim = std::numeric_limits<T>;
-
-// ADS: this should be moved into methylome.hpp
-struct methylome_metadata {
-  std::string version{};
-  std::string host{};
-  std::int64_t user{};
-  std::chrono::time_point<std::chrono::utc_clock> creation_time{};
-  std::uint64_t methylome_adler{};
-  std::uint64_t index_adler{};
-
-  static auto init(const std::string &index_filename,
-                   const std::string &methylome_filename)
-    -> std::tuple<methylome_metadata, std::error_code> {
-    std::error_code err;
-    const auto index_adler = get_adler(index_filename, err);
-    if (err)
-      return {{}, err};
-
-    const auto methylome_adler = get_adler(methylome_filename, err);
-    if (err)
-      return {{}, err};
-
-    boost::system::error_code boost_err;
-    const auto host = boost::asio::ip::host_name(boost_err);
-    if (boost_err)
-      return {{}, err};
-
-    const auto creation_time = std::chrono::utc_clock::now();
-
-    return {
-      {VERSION, host, getuid(), creation_time, methylome_adler, index_adler},
-      {}};
-  }
-
-  auto tostring() const -> std::string {
-    std::ostringstream oss;
-    println(oss,
-            "version: {}\n"
-            "host: {}\n"
-            "user: {}\n"
-            "creation_time: \"{}\"\n"
-            "methylome_adler: {}\n"
-            "index_adler: {}",
-            version, host, user, creation_time, methylome_adler, index_adler);
-    return oss.str();
-  }
-};
 
 enum class compress_err {
   // clang-format off
@@ -132,24 +73,18 @@ struct compress_err_cat : std::error_category {
   }
   auto message(const int condition) const -> std::string override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (condition) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "failed to open methylome file"s;
-    case 2:
-      return "failed to parse xcounts header"s;
-    case 3:
-      return "failed to find chromosome in xcounts header"s;
-    case 4:
-      return "inconsistent chromosome order"s;
-    case 5:
-      return "incorrect chromosome size"s;
-    case 6:
-      return "failed to generate methylome file"s;
-    case 7:
-      return "failed to write methylome file"s;
+    case 0: return "ok"s;
+    case 1: return "failed to open methylome file"s;
+    case 2: return "failed to parse xcounts header"s;
+    case 3: return "failed to find chromosome in xcounts header"s;
+    case 4: return "inconsistent chromosome order"s;
+    case 5: return "incorrect chromosome size"s;
+    case 6: return "failed to generate methylome file"s;
+    case 7: return "failed to write methylome file"s;
     }
+    // clang-format on
     std::abort();  // unreacheable
   }
 };
@@ -164,7 +99,7 @@ make_error_code(compress_err e) {
 }
 
 struct meth_file {
-  [[nodiscard]] auto open(const string &filename) -> std::error_code {
+  [[nodiscard]] auto open(const std::string &filename) -> std::error_code {
     in = gzopen(filename.data(), "rb");
     if (in == nullptr)
       return compress_err::xcounts_file_open_failure;
@@ -177,7 +112,7 @@ struct meth_file {
     return len;
   }
 
-  [[nodiscard]] auto getline(string &line) -> bool {
+  [[nodiscard]] auto getline(std::string &line) -> bool {
     line.clear();
     if (pos == len && !read())
       return false;
@@ -190,17 +125,17 @@ struct meth_file {
     return true;
   }
 
-  static constexpr int32_t buf_size = 4 * 128 * 1024;
+  static constexpr std::int32_t buf_size = 4 * 128 * 1024;
   gzFile in{};
-  int32_t pos{};
-  int32_t len{};
-  std::array<uint8_t, buf_size> buf;
+  std::int32_t pos{};
+  std::int32_t len{};
+  std::array<std::uint8_t, buf_size> buf;
 };
 
 static inline auto
-skip_absent_cpgs(const uint64_t end_pos, const cpg_index::vec &idx,
-                 uint32_t &cpg_idx_in) -> uint32_t {
-  const uint32_t first_idx = cpg_idx_in;
+skip_absent_cpgs(const std::uint64_t end_pos, const cpg_index::vec &idx,
+                 std::uint32_t &cpg_idx_in) -> std::uint32_t {
+  const std::uint32_t first_idx = cpg_idx_in;
   while (cpg_idx_in < size(idx) && idx[cpg_idx_in] < end_pos)
     ++cpg_idx_in;
   return cpg_idx_in - first_idx;
@@ -208,8 +143,8 @@ skip_absent_cpgs(const uint64_t end_pos, const cpg_index::vec &idx,
 
 // add all cpg sites for chroms in the given range
 static inline auto
-add_all_cpgs(const uint32_t prev_ch_id, const uint32_t ch_id,
-             const cpg_index &idx) -> uint32_t {
+add_all_cpgs(const std::uint32_t prev_ch_id, const std::uint32_t ch_id,
+             const cpg_index &idx) -> std::uint32_t {
   auto n_cpgs_total = 0;
   for (auto i = prev_ch_id + 1; i < ch_id; ++i)
     n_cpgs_total += size(idx.positions[i]);
@@ -217,7 +152,7 @@ add_all_cpgs(const uint32_t prev_ch_id, const uint32_t ch_id,
 }
 
 static inline auto
-get_ch_id(const cpg_index &ci, const string &chrom_name) -> int32_t {
+get_ch_id(const cpg_index &ci, const std::string &chrom_name) -> std::int32_t {
   const auto ch_id = ci.chrom_index.find(chrom_name);
   if (ch_id == cend(ci.chrom_index))
     return -1;
@@ -227,15 +162,15 @@ get_ch_id(const cpg_index &ci, const string &chrom_name) -> int32_t {
 // ADS: this function is tied to the specifics of dnmtools::xcounts
 // code, and likely needs a review
 static auto
-verify_header_line(const cpg_index &idx, int32_t &n_chroms_seen,
-                   const string &line) -> std::error_code {
+verify_header_line(const cpg_index &idx, std::int32_t &n_chroms_seen,
+                   const std::string &line) -> std::error_code {
   // ignore the version line and the header end line
   if (line.substr(0, 9) == "#DNMTOOLS" || size(line) == 1)
     return compress_err::ok;
 
   // parse the chrom and its size
-  string chrom;
-  uint64_t chrom_size{};
+  std::string chrom;
+  std::uint64_t chrom_size{};
   std::istringstream iss{line};
   if (!(iss >> chrom >> chrom_size))
     return compress_err::xcounts_file_header_failure;
@@ -264,46 +199,45 @@ verify_header_line(const cpg_index &idx, int32_t &n_chroms_seen,
 }
 
 static auto
-process_cpg_sites(const string &infile, const string &outfile,
+process_cpg_sites(const std::string &infile, const std::string &outfile,
                   const cpg_index &index, const bool zip) -> std::error_code {
   meth_file mf{};
   std::error_code err = mf.open(infile);
   if (err != compress_err::ok) {
-    println("Error reading xcounts file: {}", infile);
+    std::println("Error reading xcounts file: {}", infile);
     return err;
   }
 
   methylome::vec cpgs(index.n_cpgs_total, {0, 0});
 
-  uint32_t cpg_idx_out{};  // index of current output cpg position
-  uint32_t cpg_idx_in{};   // index of current input cpg position
-  int32_t prev_ch_id = -1;
-  uint64_t pos = num_lim<uint64_t>::max();
+  std::uint32_t cpg_idx_out{};  // index of current output cpg position
+  std::uint32_t cpg_idx_in{};   // index of current input cpg position
+  std::int32_t prev_ch_id = -1;
+  std::uint64_t pos = std::numeric_limits<std::uint64_t>::max();
 
-  vector<cpg_index::vec>::const_iterator positions{};
+  std::vector<cpg_index::vec>::const_iterator positions{};
 
-  unordered_map<string, int32_t> header_chroms_index;
-
-  string line;
-  int32_t n_chroms_seen{};
+  std::string line;
+  std::int32_t n_chroms_seen{};
   while (mf.getline(line)) {
     if (line[0] == '#') {
       // consistency check between reference used for the index and
       // reference used for the methylome
       if (err = verify_header_line(index, n_chroms_seen, line); err) {
-        println("Error parsing xcounts header line: {} ({})", line, err);
+        std::println("Error parsing xcounts header line: {} ({})", line, err);
         return err;
       }
       continue;  // ADS: early loop exit
     }
-    if (!std::isdigit(line[0])) {           // check for new chromosome
-      if (pos != num_lim<uint64_t>::max())  // check not first iteration
+    if (!std::isdigit(line[0])) {  // check for new chromosome
+      // check not first iteration
+      if (pos != std::numeric_limits<std::uint64_t>::max())
         // add cpgs before those in the input
         cpg_idx_out += (size(*positions) - cpg_idx_in);
 
-      const int32_t ch_id = get_ch_id(index, line);
+      const std::int32_t ch_id = get_ch_id(index, line);
       if (ch_id < 0) {
-        println("Failed to find chromosome in index: {}", line);
+        std::println("Failed to find chromosome in index: {}", line);
         return compress_err::xcounts_file_chromosome_not_found;
       }
 
@@ -315,11 +249,11 @@ process_cpg_sites(const string &infile, const string &outfile,
       prev_ch_id = ch_id;
     }
     else {
-      uint32_t pos_step = 0, n_meth = 0, n_unmeth = 0;
+      std::uint32_t pos_step = 0, n_meth = 0, n_unmeth = 0;
       const auto end_line = line.data() + size(line);
-      auto res = from_chars(line.data(), end_line, pos_step);
-      res = from_chars(res.ptr + 1, end_line, n_meth);
-      res = from_chars(res.ptr + 1, end_line, n_unmeth);
+      auto res = std::from_chars(line.data(), end_line, pos_step);
+      res = std::from_chars(res.ptr + 1, end_line, n_meth);
+      res = std::from_chars(res.ptr + 1, end_line, n_unmeth);
       // ADS: check for errors here
 
       const auto curr_pos = pos + pos_step;
@@ -339,7 +273,7 @@ process_cpg_sites(const string &infile, const string &outfile,
   cpg_idx_out += add_all_cpgs(prev_ch_id, size(index.positions), index);
 
   if (cpg_idx_out != index.n_cpgs_total) {
-    println("Failed to generate mxe methylome");
+    std::println("Failed to generate mxe methylome");
     return compress_err::methylome_compression_failure;
   }
 
@@ -347,7 +281,7 @@ process_cpg_sites(const string &infile, const string &outfile,
   m.cpgs = std::move(cpgs);
   const auto meth_write_err = m.write(outfile, zip);
   if (meth_write_err) {
-    println("Error: {} ({})", meth_write_err, outfile);
+    std::println("Error: {} ({})", meth_write_err, outfile);
     return compress_err::methylome_file_write_failure;
   }
 
@@ -358,74 +292,94 @@ process_cpg_sites(const string &infile, const string &outfile,
 
 auto
 compress_main(int argc, char *argv[]) -> int {
-  static const auto description = "compress";
+  static constexpr mxe_log_level default_log_level = mxe_log_level::info;
+  static constexpr auto command = "compress";
 
-  bool verbose{};
-  bool zip{};
+  std::string methylation_input{};
+  std::string methylome_output{};
+  std::string metadata_output{};
+  std::string index_file{};
+  mxe_log_level log_level{};
+  bool zip{false};
 
-  string methylation_input{};
-  string methylation_output{};
-  string index_file{};
+  namespace po = boost::program_options;
 
-  po::options_description desc(description);
+  po::options_description desc(std::format("Usage: mxe {} [options]", command));
   desc.add_options()
     // clang-format off
     ("help,h", "produce help message")
-    ("meth,m", value(&methylation_input)->required(),
+    ("meth,m", po::value(&methylation_input)->required(),
      "methylation input file")
-    ("index,x", value(&index_file)->required(), "index file")
-    ("output,o", value(&methylation_output)->required(),
-     "methylation output file")
+    ("index,x", po::value(&index_file)->required(), "index file")
+    ("output,o", po::value(&methylome_output)->required(),
+     "methylome output file")
+    ("meta-out", po::value(&metadata_output),
+     "metadata output (defaults to output.json)")
     ("zip,z", po::bool_switch(&zip), "zip the output")
-    ("verbose,v", po::bool_switch(&verbose), "print more run info")
+    ("log-level,v", po::value(&log_level)->default_value(default_log_level),
+     "log level {debug,info,warning,error,critical}")
     // clang-format on
     ;
   try {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    if (vm.count("help")) {
+    if (vm.count("help") || argc == 1) {
       desc.print(std::cout);
       return EXIT_SUCCESS;
     }
     po::notify(vm);
   }
   catch (po::error &e) {
-    println("{}", e.what());
+    std::println("{}", e.what());
     desc.print(std::cout);
     return EXIT_FAILURE;
   }
 
-  if (verbose)
-    print("methylome file: {}\n"
-          "index file: {}\n"
-          "output file: {}\n"
-          "zip: {}\n",
-          methylation_input, methylation_output, index_file, zip);
+  auto &lgr = logger::instance(shared_from_cout(), command, log_level);
+  if (!lgr) {
+    std::println("Failure initializing logging: {}.", lgr.get_status());
+    return EXIT_FAILURE;
+  }
+
+  if (metadata_output.empty())
+    metadata_output = std::format("{}.json", methylome_output);
+
+  std::vector<std::tuple<std::string, std::string>> args_to_log{
+    // clang-format off
+    {"Methylation", methylation_input},
+    {"Index", index_file},
+    {"Methylome output", methylome_output},
+    {"Metadata output", metadata_output},
+    {"Zip", std::format("{}", zip)},
+    // clang-format on
+  };
+  log_args<mxe_log_level::info>(args_to_log);
 
   cpg_index index{};
   if (const auto index_read_err = index.read(index_file); index_read_err) {
-    println("Error: {} ({})", index_read_err, index_file);
+    lgr.error("Error reading cpg index {}: {}", index_read_err, index_file);
     return EXIT_FAILURE;
   }
-
-  if (verbose)
-    println("{}", index);
 
   std::error_code err =
-    process_cpg_sites(methylation_input, methylation_output, index, zip);
+    process_cpg_sites(methylation_input, methylome_output, index, zip);
   if (err) {
-    println("Error : {}", err);
+    lgr.error("Error generating methylome: {}", err);
     return EXIT_FAILURE;
   }
 
-  const auto [mm, metadata_err] =
-    methylome_metadata::init(index_file, methylation_output);
+  const auto [metadata, metadata_err] =
+    methylome_metadata::init(index_file, methylome_output, zip);
   if (metadata_err) {
-    println("Error : {}", metadata_err);
+    lgr.error("Error initializing metadata: {}", metadata_err);
     return EXIT_FAILURE;
   }
 
-  println("{}", mm.tostring());
+  err = methylome_metadata::write(metadata, metadata_output);
+  if (err) {
+    lgr.error("Error writing metadata: {} ({})", err, metadata_output);
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -71,10 +71,11 @@ connection::read_request() -> void {
                 respond_with_error();
               }
             }
-            else {  // only possibility is req_hdr.is_counts_request()
+            else {  // only possibility is req_hdr.is_bins_request()
               if (const auto req_parse =
                     from_chars(req_hdr_parse.ptr, cend(req_hdr_buf), bins_req);
                   !req_parse.error) {
+                handler.add_response_size_for_bins(req_hdr, bins_req, resp_hdr);
                 compute_bins();
               }
               else {

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -67,6 +67,7 @@ struct connection : public std::enable_shared_from_this<connection> {
 
   auto read_request() -> void;  // read request
   auto read_offsets() -> void;  // read offsets part of request
+  auto compute_bins() -> void;  // do the computation for bins
 
   auto respond_with_header() -> void;  // write good header
   auto respond_with_error() -> void;   // write error header
@@ -80,6 +81,7 @@ struct connection : public std::enable_shared_from_this<connection> {
   request_header_buffer req_hdr_buf{};
   request_header req_hdr;  // this connection's request header
   request req;             // this connection's request
+  bins_request bins_req;   // this connection's bins request
   response_header_buffer resp_hdr_buf{};
   response_header resp_hdr;  // header of the response
   response_payload resp;     // response to send back

--- a/src/cpg_index.cpp
+++ b/src/cpg_index.cpp
@@ -462,6 +462,16 @@ cpg_index::get_offsets(const std::vector<genomic_interval> &gis) const
   return offsets;
 }
 
+[[nodiscard]] auto
+cpg_index::get_n_bins(const std::uint32_t bin_size) const -> std::uint32_t {
+  const auto get_n_bins_for_chrom = [&](const auto chrom_size) {
+    return (chrom_size + bin_size) / bin_size;
+  };
+  return std::transform_reduce(std::cbegin(chrom_size), std::cend(chrom_size),
+                               static_cast<std::uint32_t>(0), std::plus{},
+                               get_n_bins_for_chrom);
+}
+
 auto
 get_assembly_from_filename(const std::string &filename,
                            std::error_code &ec) -> std::string {

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -47,16 +47,11 @@ struct cpg_index {
 #else
   typedef std::vector<cpg_pos_t> vec;
 #endif
-  auto
-  construct(const std::string &genome_file) -> std::error_code;
-  auto
-  read(const std::string &index_file) -> std::error_code;
-  auto
-  write(const std::string &index_file) const -> std::error_code;
-  auto
-  tostring() const -> std::string;
-  [[nodiscard]] auto
-  hash() const -> std::size_t;
+  auto construct(const std::string &genome_file) -> std::error_code;
+  auto read(const std::string &index_file) -> std::error_code;
+  auto write(const std::string &index_file) const -> std::error_code;
+  auto tostring() const -> std::string;
+  [[nodiscard]] auto hash() const -> std::size_t;
 
   // given the chromosome id (from chrom_index) and a position within
   // the chrom, get the offset of the CpG site from std::lower_bound
@@ -64,8 +59,7 @@ struct cpg_index {
   // [[nodiscard]] auto
   // get_offset_within_chrom(const std::int32_t ch_id,
   //                         const std::uint32_t pos) const -> std::uint32_t;
-  [[nodiscard]] auto
-  get_offsets_within_chrom(
+  [[nodiscard]] auto get_offsets_within_chrom(
     const std::int32_t ch_id,
     const std::vector<std::pair<std::uint32_t, std::uint32_t>> &pos) const
     -> std::vector<std::pair<std::uint32_t, std::uint32_t>>;
@@ -78,8 +72,7 @@ struct cpg_index {
 
   // get the offset from the start of the data structure given genomic
   // intervals
-  [[nodiscard]] auto
-  get_offsets(const std::vector<genomic_interval> &gis) const
+  [[nodiscard]] auto get_offsets(const std::vector<genomic_interval> &gis) const
     -> std::vector<std::pair<std::uint32_t, std::uint32_t>>;
 
   [[nodiscard]] auto
@@ -94,8 +87,7 @@ struct cpg_index {
 };
 
 template <> struct std::formatter<cpg_index> : std::formatter<std::string> {
-  auto
-  format(const cpg_index &ci, std::format_context &ctx) const {
+  auto format(const cpg_index &ci, std::format_context &ctx) const {
     return std::formatter<std::string>::format(ci.tostring(), ctx);
   }
 };

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -60,9 +60,10 @@ struct cpg_index {
 
   // given the chromosome id (from chrom_index) and a position within
   // the chrom, get the offset of the CpG site from std::lower_bound
-  [[nodiscard]] auto
-  get_offset_within_chrom(const std::int32_t ch_id,
-                          const std::uint32_t pos) const -> std::uint32_t;
+  /* ADS: currently unused */
+  // [[nodiscard]] auto
+  // get_offset_within_chrom(const std::int32_t ch_id,
+  //                         const std::uint32_t pos) const -> std::uint32_t;
   [[nodiscard]] auto
   get_offsets_within_chrom(
     const std::int32_t ch_id,

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -47,18 +47,24 @@ struct cpg_index {
 #else
   typedef std::vector<cpg_pos_t> vec;
 #endif
-  auto construct(const std::string &genome_file) -> std::error_code;
-  auto read(const std::string &index_file) -> std::error_code;
-  auto write(const std::string &index_file) const -> std::error_code;
-  auto tostring() const -> std::string;
-  [[nodiscard]] auto hash() const -> std::size_t;
+  auto
+  construct(const std::string &genome_file) -> std::error_code;
+  auto
+  read(const std::string &index_file) -> std::error_code;
+  auto
+  write(const std::string &index_file) const -> std::error_code;
+  auto
+  tostring() const -> std::string;
+  [[nodiscard]] auto
+  hash() const -> std::size_t;
 
   // given the chromosome id (from chrom_index) and a position within
   // the chrom, get the offset of the CpG site from std::lower_bound
   [[nodiscard]] auto
   get_offset_within_chrom(const std::int32_t ch_id,
                           const std::uint32_t pos) const -> std::uint32_t;
-  [[nodiscard]] auto get_offsets_within_chrom(
+  [[nodiscard]] auto
+  get_offsets_within_chrom(
     const std::int32_t ch_id,
     const std::vector<std::pair<std::uint32_t, std::uint32_t>> &pos) const
     -> std::vector<std::pair<std::uint32_t, std::uint32_t>>;
@@ -71,8 +77,12 @@ struct cpg_index {
 
   // get the offset from the start of the data structure given genomic
   // intervals
-  [[nodiscard]] auto get_offsets(const std::vector<genomic_interval> &gis) const
+  [[nodiscard]] auto
+  get_offsets(const std::vector<genomic_interval> &gis) const
     -> std::vector<std::pair<std::uint32_t, std::uint32_t>>;
+
+  [[nodiscard]] auto
+  get_n_bins(const std::uint32_t bin_size) const -> std::uint32_t;
 
   std::vector<std::string> chrom_order;
   std::vector<std::uint32_t> chrom_size;
@@ -83,7 +93,8 @@ struct cpg_index {
 };
 
 template <> struct std::formatter<cpg_index> : std::formatter<std::string> {
-  auto format(const cpg_index &ci, std::format_context &ctx) const {
+  auto
+  format(const cpg_index &ci, std::format_context &ctx) const {
     return std::formatter<std::string>::format(ci.tostring(), ctx);
   }
 };

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -39,6 +39,8 @@
 struct genomic_interval;
 
 struct cpg_index {
+  static constexpr auto filename_extension{"cpg_idx"};
+
   typedef std::uint32_t cpg_pos_t;
 #if not defined(__APPLE__) && not defined(__MACH__)
   typedef std::vector<cpg_pos_t, aligned_allocator<cpg_pos_t>> vec;
@@ -85,5 +87,9 @@ template <> struct std::formatter<cpg_index> : std::formatter<std::string> {
     return std::formatter<std::string>::format(ci.tostring(), ctx);
   }
 };
+
+auto
+get_assembly_from_filename(const std::string &filename,
+                           std::error_code &ec) -> std::string;
 
 #endif  // SRC_CPG_INDEX_HPP_

--- a/src/cpg_index_set.cpp
+++ b/src/cpg_index_set.cpp
@@ -36,6 +36,16 @@
 #include <unordered_map>
 
 [[nodiscard]] auto
+cpg_index_set::get_genome_sizes()
+  -> std::unordered_map<std::string, std::uint64_t> {
+  std::unordered_map<std::string, std::uint64_t> r;
+  for (const auto [assembly, idx] : assembly_to_cpg_index)
+    r.emplace(assembly, std::reduce(std::cbegin(idx.chrom_size),
+                                    std::cend(idx.chrom_size)));
+  return r;
+}
+
+[[nodiscard]] auto
 cpg_index_set::get_cpg_index(const std::string &assembly_name)
   -> std::tuple<const cpg_index &, std::error_code> {
   const auto itr = assembly_to_cpg_index.find(assembly_name);

--- a/src/cpg_index_set.cpp
+++ b/src/cpg_index_set.cpp
@@ -46,8 +46,9 @@ cpg_index_set::get_cpg_index(const std::string &assembly_name)
 
 cpg_index_set::cpg_index_set(const std::string &cpg_index_directory) :
   cpg_index_directory{cpg_index_directory} {
-  static constexpr auto cpg_index_filename_ptrn = R"(^[_[:alnum:]]+.cpg_idx$)";
   static constexpr auto assembly_ptrn = R"(^[_[:alnum:]]+)";
+  static const auto cpg_index_filename_ptrn =
+    std::format(R"({}.{}$)", assembly_ptrn, cpg_index::filename_extension);
   std::regex cpg_index_filename_re(cpg_index_filename_ptrn);
   std::regex assembly_re(assembly_ptrn);
 

--- a/src/cpg_index_set.cpp
+++ b/src/cpg_index_set.cpp
@@ -1,0 +1,65 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "cpg_index_set.hpp"
+
+#include "cpg_index.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <format>
+#include <regex>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+
+[[nodiscard]] auto
+cpg_index_set::get_cpg_index(const std::string &assembly_name)
+  -> std::tuple<const cpg_index &, std::error_code> {
+  const auto itr = assembly_to_cpg_index.find(assembly_name);
+  if (itr == std::cend(assembly_to_cpg_index))
+    return {{}, std::make_error_code(std::errc::invalid_argument)};
+  return {itr->second, {}};
+}
+
+cpg_index_set::cpg_index_set(const std::string &cpg_index_directory) :
+  cpg_index_directory{cpg_index_directory} {
+  static constexpr auto cpg_index_filename_ptrn = R"(^[_[:alnum:]]+.cpg_idx$)";
+  static constexpr auto assembly_ptrn = R"(^[_[:alnum:]]+)";
+  std::regex cpg_index_filename_re(cpg_index_filename_ptrn);
+  std::regex assembly_re(assembly_ptrn);
+
+  const std::filesystem::path idx_dir{cpg_index_directory};
+  for (auto const &dir_entry : std::filesystem::directory_iterator{idx_dir}) {
+    const std::string name = dir_entry.path().filename().string();
+    if (std::regex_search(name, cpg_index_filename_re)) {
+      std::smatch base_match;
+      if (std::regex_search(name, base_match, assembly_re)) {
+        const auto assembly = base_match[0].str();
+        cpg_index index;
+        index.construct(dir_entry.path().string());
+        assembly_to_cpg_index.emplace(assembly, index);
+      }
+    }
+  }
+}

--- a/src/cpg_index_set.cpp
+++ b/src/cpg_index_set.cpp
@@ -35,15 +35,15 @@
 #include <tuple>
 #include <unordered_map>
 
-[[nodiscard]] auto
-cpg_index_set::get_genome_sizes()
-  -> std::unordered_map<std::string, std::uint64_t> {
-  std::unordered_map<std::string, std::uint64_t> r;
-  for (const auto [assembly, idx] : assembly_to_cpg_index)
-    r.emplace(assembly, std::reduce(std::cbegin(idx.chrom_size),
-                                    std::cend(idx.chrom_size)));
-  return r;
-}
+// [[nodiscard]] auto
+// cpg_index_set::get_genome_sizes()
+//   -> std::unordered_map<std::string, std::uint64_t> {
+//   std::unordered_map<std::string, std::uint64_t> r;
+//   for (const auto [assembly, idx] : assembly_to_cpg_index)
+//     r.emplace(assembly, std::reduce(std::cbegin(idx.chrom_size),
+//                                     std::cend(idx.chrom_size)));
+//   return r;
+// }
 
 [[nodiscard]] auto
 cpg_index_set::get_cpg_index(const std::string &assembly_name)

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -34,13 +34,11 @@
 
 struct cpg_index_set {
   cpg_index_set(const cpg_index_set &) = delete;
-  cpg_index_set &
-  operator=(const cpg_index_set &) = delete;
+  cpg_index_set &operator=(const cpg_index_set &) = delete;
 
   explicit cpg_index_set(const std::string &cpg_index_directory);
 
-  [[nodiscard]] auto
-  get_cpg_index(const std::string &assembly_name)
+  [[nodiscard]] auto get_cpg_index(const std::string &assembly_name)
     -> std::tuple<const cpg_index &, std::error_code>;
 
   /* ADS: currently unused */

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -26,6 +26,7 @@
 
 #include "cpg_index.hpp"
 
+#include <cstdint>  // for std::uint64_t
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -33,12 +34,17 @@
 
 struct cpg_index_set {
   cpg_index_set(const cpg_index_set &) = delete;
-  cpg_index_set &operator=(const cpg_index_set &) = delete;
+  cpg_index_set &
+  operator=(const cpg_index_set &) = delete;
 
   explicit cpg_index_set(const std::string &cpg_index_directory);
 
-  [[nodiscard]] auto get_cpg_index(const std::string &assembly_name)
+  [[nodiscard]] auto
+  get_cpg_index(const std::string &assembly_name)
     -> std::tuple<const cpg_index &, std::error_code>;
+
+  [[nodiscard]] auto
+  get_genome_sizes() -> std::unordered_map<std::string, std::uint64_t>;
 
   std::string cpg_index_directory;
   std::unordered_map<std::string, cpg_index> assembly_to_cpg_index;

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -40,8 +40,6 @@ struct cpg_index_set {
   [[nodiscard]] auto get_cpg_index(const std::string &assembly_name)
     -> std::tuple<const cpg_index &, std::error_code>;
 
-  static constexpr auto cpg_index_extension{"cpg_index"};
-
   std::string cpg_index_directory;
   std::unordered_map<std::string, cpg_index> assembly_to_cpg_index;
 };

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -1,0 +1,49 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_CPG_INDEX_SET_HPP_
+#define SRC_CPG_INDEX_SET_HPP_
+
+#include "cpg_index.hpp"
+
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+struct cpg_index_set {
+  cpg_index_set(const cpg_index_set &) = delete;
+  cpg_index_set &operator=(const cpg_index_set &) = delete;
+
+  explicit cpg_index_set(const std::string &cpg_index_directory);
+
+  [[nodiscard]] auto get_cpg_index(const std::string &assembly_name)
+    -> std::tuple<const cpg_index &, std::error_code>;
+
+  static constexpr auto cpg_index_extension{"cpg_index"};
+
+  std::string cpg_index_directory;
+  std::unordered_map<std::string, cpg_index> assembly_to_cpg_index;
+};
+
+#endif  // SRC_CPG_INDEX_SET_HPP_

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -43,8 +43,9 @@ struct cpg_index_set {
   get_cpg_index(const std::string &assembly_name)
     -> std::tuple<const cpg_index &, std::error_code>;
 
-  [[nodiscard]] auto
-  get_genome_sizes() -> std::unordered_map<std::string, std::uint64_t>;
+  /* ADS: currently unused */
+  // [[nodiscard]] auto
+  // get_genome_sizes() -> std::unordered_map<std::string, std::uint64_t>;
 
   std::string cpg_index_directory;
   std::unordered_map<std::string, cpg_index> assembly_to_cpg_index;

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -38,6 +38,8 @@
 #include <chrono>
 #include <cstdint>  // std::uint32_t
 #include <cstring>  // std::memcpy
+#include <format>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <ostream>
@@ -87,9 +89,6 @@ static constexpr auto level_name_sz{[]() constexpr {
   return tmp;
 }()};
 
-/*
-  print std::filesystem::path
- */
 template <> struct std::formatter<mxe_log_level> : std::formatter<std::string> {
   auto format(const mxe_log_level &l, std::format_context &ctx) const {
     return std::formatter<std::string>::format(
@@ -114,6 +113,11 @@ operator>>(std::istream &in, mxe_log_level &l) {
     }
   in.setstate(std::ios::failbit);
   return in;
+}
+
+[[nodiscard]] inline auto
+shared_from_cout() -> std::shared_ptr<std::ostream> {
+  return std::make_shared<std::ostream>(std::cout.rdbuf());
 }
 
 class logger {

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -42,7 +42,6 @@
 #include <fstream>
 #include <iostream>
 #include <print>
-#include <ranges>
 #include <string>
 #include <system_error>
 #include <tuple>
@@ -50,7 +49,6 @@
 #include <vector>
 
 using std::string;
-using std::tuple;
 using std::vector;
 
 template <typename counts_res_type>
@@ -58,7 +56,7 @@ template <typename counts_res_type>
 do_remote_lookup(const string &accession, const cpg_index &index,
                  vector<methylome::offset_pair> offsets, const string &hostname,
                  const string &port)
-  -> tuple<vector<counts_res_type>, std::error_code> {
+  -> std::tuple<vector<counts_res_type>, std::error_code> {
   request_header hdr{accession, index.n_cpgs_total, {}};
 
   if constexpr (std::is_same<counts_res_type, counts_res>::value)
@@ -82,7 +80,7 @@ template <typename counts_res_type>
 [[nodiscard]] static inline auto
 do_local_lookup(const string &meth_file, const string &meth_meta_file,
                 const cpg_index &index, vector<methylome::offset_pair> offsets)
-  -> tuple<vector<counts_res_type>, std::error_code> {
+  -> std::tuple<vector<counts_res_type>, std::error_code> {
   const auto [meta, meta_err] = methylome_metadata::read(meth_meta_file);
   if (meta_err) {
     logger::instance().error("Error: {} ({})", meta_err, meth_meta_file);
@@ -262,18 +260,18 @@ lookup_main(int argc, char *argv[]) -> int {
   }
 
   // ADS: log the command line arguments (assuming right log level)
-  vector<tuple<string, string>> args_to_log{
+  vector<std::tuple<string, string>> args_to_log{
     {"Index", index_file},
     {"Intervals", intervals_file},
     {"Output", output_file},
     {"Covered", std::format("{}", count_covered)},
     {"Bedgraph", std::format("{}", write_scores)},
   };
-  vector<tuple<string, string>> remote_args{
+  vector<std::tuple<string, string>> remote_args{
     {"Hostname:port", std::format("{}:{}", hostname, port)},
     {"Accession", accession},
   };
-  vector<tuple<string, string>> local_args{
+  vector<std::tuple<string, string>> local_args{
     {"Methylome", meth_file},
     {"Metadata", meth_meta_file},
   };

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -28,6 +28,7 @@
 #include "genomic_interval.hpp"
 #include "logger.hpp"
 #include "methylome.hpp"
+#include "methylome_metadata.hpp"
 #include "mxe_error.hpp"
 #include "request.hpp"
 #include "response.hpp"
@@ -228,7 +229,7 @@ lookup_main(int argc, char *argv[]) -> int {
   po::options_description local("Local");
   local.add_options()
     ("methylome,m", po::value(&meth_file)->required(), "local methylome file")
-    ("metadata", po::value(&meth_meta_file)->required(), "methylome metadata file")
+    ("metadata", po::value(&meth_meta_file), "methylome metadata file")
     ;
   // clang-format on
 
@@ -239,7 +240,7 @@ lookup_main(int argc, char *argv[]) -> int {
   try {
     po::variables_map vm;
     po::store(po::parse_command_line(argc - 1, argv + 1, all), vm);
-    if (vm.count("help")) {
+    if (vm.count("help") || argc == 1) {
       all.print(std::cout);
       return EXIT_SUCCESS;
     }
@@ -250,6 +251,9 @@ lookup_main(int argc, char *argv[]) -> int {
     all.print(std::cout);
     return EXIT_FAILURE;
   }
+
+  if (meth_meta_file.empty())
+    meth_meta_file = get_default_methylome_metadata_filename(meth_file);
 
   logger &lgr = logger::instance(shared_from_cout(), command, log_level);
   if (!lgr) {

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -40,7 +40,6 @@
 #include <format>
 #include <fstream>
 #include <iostream>
-#include <memory>  // std::make_shared
 #include <print>
 #include <ranges>
 #include <string>
@@ -252,8 +251,7 @@ lookup_main(int argc, char *argv[]) -> int {
     return EXIT_FAILURE;
   }
 
-  logger &lgr = logger::instance(
-    std::make_shared<std::ostream>(std::cout.rdbuf()), command, log_level);
+  logger &lgr = logger::instance(shared_from_cout(), command, log_level);
   if (!lgr) {
     std::println("Failure initializing logging: {}.", lgr.get_status());
     return EXIT_FAILURE;

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -151,7 +151,7 @@ auto
 lookup_main(int argc, char *argv[]) -> int {
   static constexpr auto usage_format =
     "Usage: mxe lookup {} [options]\n\nOption groups";
-  static constexpr mxe_log_level default_log_level = mxe_log_level::warning;
+  static constexpr mxe_log_level default_log_level = mxe_log_level::info;
   static constexpr auto default_port = "5000";
   static const auto command = "lookup";
 

--- a/src/methylome.cpp
+++ b/src/methylome.cpp
@@ -45,8 +45,8 @@ using hr_clock = std::chrono::high_resolution_clock;
 #endif
 
 [[nodiscard]] auto
-methylome::read(const std::string &filename,
-                const std::uint32_t n_cpgs) -> std::error_code {
+methylome::read(const std::string &filename, const std::uint32_t n_cpgs)
+  -> std::error_code {
   std::error_code ec;
   const auto filesize = std::filesystem::file_size(filename, ec);
   if (ec)
@@ -105,8 +105,8 @@ methylome::read(const std::string &filename,
 }
 
 [[nodiscard]] auto
-methylome::write(const std::string &filename,
-                 const bool zip) const -> std::error_code {
+methylome::write(const std::string &filename, const bool zip) const
+  -> std::error_code {
   std::vector<std::uint8_t> buf;
   if (zip) {
 #ifdef BENCHMARK
@@ -207,8 +207,8 @@ methylome::get_counts_cov(const std::uint32_t start,
 }
 
 [[nodiscard]] auto
-methylome::get_counts(const std::uint32_t start,
-                      const std::uint32_t stop) const -> counts_res {
+methylome::get_counts(const std::uint32_t start, const std::uint32_t stop) const
+  -> counts_res {
   return get_counts_impl<counts_res>(std::cbegin(cpgs) + start,
                                      std::cbegin(cpgs) + stop);
 }
@@ -225,8 +225,9 @@ methylome::get_counts_cov(
 }
 
 [[nodiscard]] auto
-methylome::get_counts(const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-                        &queries) const -> std::vector<counts_res> {
+methylome::get_counts(
+  const std::vector<std::pair<std::uint32_t, std::uint32_t>> &queries) const
+  -> std::vector<counts_res> {
   std::vector<counts_res> res(std::size(queries));
   const auto beg = std::cbegin(cpgs);
   for (const auto [i, q] : std::views::enumerate(queries))
@@ -277,8 +278,7 @@ bin_counts_impl(cpg_index::vec::const_iterator &posn_itr,
 }
 
 template <typename T>
-[[nodiscard]]
-static auto
+[[nodiscard]] static auto
 get_bins_impl(const std::uint32_t bin_size, const cpg_index &index,
               const methylome::vec &cpgs) -> std::vector<T> {
   std::vector<T> results;  // ADS TODO: reserve n_bins
@@ -298,15 +298,15 @@ get_bins_impl(const std::uint32_t bin_size, const cpg_index &index,
   return results;
 }
 
-// [[nodiscard]] auto
-// methylome::get_bins(const std::uint32_t bin_size,
-//                     const cpg_index &index) const -> std::vector<counts_res>
-//                     {
-//   return get_bins_impl<counts_res>(bin_size, index, cpgs);
-// }
+[[nodiscard]] auto
+methylome::get_bins(const std::uint32_t bin_size, const cpg_index &index) const
+  -> std::vector<counts_res> {
+  return get_bins_impl<counts_res>(bin_size, index, cpgs);
+}
 
 [[nodiscard]] auto
-methylome::get_bins_cov(const std::uint32_t bin_size, const cpg_index &index)
-  const -> std::vector<counts_res_cov> {
+methylome::get_bins_cov(const std::uint32_t bin_size,
+                        const cpg_index &index) const
+  -> std::vector<counts_res_cov> {
   return get_bins_impl<counts_res_cov>(bin_size, index, cpgs);
 }

--- a/src/methylome.cpp
+++ b/src/methylome.cpp
@@ -118,7 +118,7 @@ methylome::write(const std::string &filename,
       return compress_err;
   }
 
-  std::ofstream out(filename);
+  std::ofstream out(filename, std::ios::binary);
   if (!out)
     return std::make_error_code(std::errc(errno));
 

--- a/src/methylome.cpp
+++ b/src/methylome.cpp
@@ -73,8 +73,8 @@ methylome::read(const std::string &filename,
 
   if (metadata.is_compressed) {
     std::vector<std::uint8_t> buf(filesize);
-    const bool read_ok =
-      in.read(reinterpret_cast<char *>(buf.data()), filesize);
+    const bool read_ok = static_cast<bool>(
+      in.read(reinterpret_cast<char *>(buf.data()), filesize));
     const auto n_bytes = in.gcount();
     if (!read_ok || n_bytes != static_cast<std::streamsize>(filesize))
       return methylome_code::error_reading_methylome;
@@ -91,7 +91,8 @@ methylome::read(const std::string &filename,
     return decompress_err;
   }
   cpgs.resize(metadata.n_cpgs);
-  const bool read_ok = in.read(reinterpret_cast<char *>(cpgs.data()), filesize);
+  const bool read_ok =
+    static_cast<bool>(in.read(reinterpret_cast<char *>(cpgs.data()), filesize));
   const auto n_bytes = in.gcount();
   if (!read_ok || n_bytes != static_cast<std::streamsize>(filesize))
     return methylome_code::error_reading_methylome;

--- a/src/methylome.hpp
+++ b/src/methylome.hpp
@@ -81,8 +81,8 @@ struct methylome {
 
   [[nodiscard]] auto
   get_counts_cov(const cpg_index::vec &positions, const std::uint32_t offset,
-                 const std::uint32_t start,
-                 const std::uint32_t stop) const -> counts_res_cov;
+                 const std::uint32_t start, const std::uint32_t stop) const
+    -> counts_res_cov;
   [[nodiscard]] auto get_counts(const cpg_index::vec &positions,
                                 const std::uint32_t offset,
                                 const std::uint32_t start,
@@ -90,9 +90,9 @@ struct methylome {
 
   // takes only the pair of positions within the methylome::vec
   // and accumulates between those
-  [[nodiscard]] auto
-  get_counts_cov(const std::uint32_t start,
-                 const std::uint32_t stop) const -> counts_res_cov;
+  [[nodiscard]] auto get_counts_cov(const std::uint32_t start,
+                                    const std::uint32_t stop) const
+    -> counts_res_cov;
   [[nodiscard]] auto get_counts(const std::uint32_t start,
                                 const std::uint32_t stop) const -> counts_res;
 
@@ -110,12 +110,12 @@ struct methylome {
 
   // takes a bins size and a cpg_index and calculates the counts in
   // each bin along all chromosomes
-  // [[nodiscard]] auto
-  // get_bins(const std::uint32_t bin_size,
-  //          const cpg_index &index) const -> std::vector<counts_res>;
-  [[nodiscard]] auto
-  get_bins_cov(const std::uint32_t bin_size,
-               const cpg_index &index) const -> std::vector<counts_res_cov>;
+  [[nodiscard]] auto get_bins(const std::uint32_t bin_size,
+                              const cpg_index &index) const
+    -> std::vector<counts_res>;
+  [[nodiscard]] auto get_bins_cov(const std::uint32_t bin_size,
+                                  const cpg_index &index) const
+    -> std::vector<counts_res_cov>;
 
   methylome::vec cpgs{};
   static constexpr auto record_size = sizeof(m_elem);

--- a/src/methylome.hpp
+++ b/src/methylome.hpp
@@ -27,8 +27,10 @@
 #if not defined(__APPLE__) && not defined(__MACH__)
 #include "aligned_allocator.hpp"
 #endif
+
 #include "cpg_index.hpp"
 #include "methylome_metadata.hpp"
+#include "methylome_results_types.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -36,36 +38,6 @@
 #include <system_error>
 #include <utility>  // pair<>
 #include <vector>
-
-struct counts_res {
-  std::uint32_t n_meth{};
-  std::uint32_t n_unmeth{};
-};
-
-struct counts_res_cov {
-  std::uint32_t n_meth{};
-  std::uint32_t n_unmeth{};
-  std::uint32_t n_covered{};
-};
-
-template <> struct std::formatter<counts_res> : std::formatter<std::string> {
-  auto format(const counts_res &cr, std::format_context &ctx) const {
-    return std::formatter<std::string>::format(
-      std::format(R"({{"n_meth": {}, "n_unmeth": {}}})", cr.n_meth,
-                  cr.n_unmeth),
-      ctx);
-  }
-};
-
-template <>
-struct std::formatter<counts_res_cov> : std::formatter<std::string> {
-  auto format(const counts_res_cov &cr, std::format_context &ctx) const {
-    return std::formatter<std::string>::format(
-      std::format(R"({{"n_meth": {}, "n_unmeth": {}, "n_covered": {}}})",
-                  cr.n_meth, cr.n_unmeth, cr.n_covered),
-      ctx);
-  }
-};
 
 // ADS TODO: n_cpgs in header
 struct methylome {

--- a/src/methylome_metadata.cpp
+++ b/src/methylome_metadata.cpp
@@ -1,0 +1,148 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "methylome_metadata.hpp"
+
+#include "automatic_json.hpp"
+#include "cpg_index.hpp"  // get_assembly_from_filename
+
+#include <config.h>
+
+#include <boost/asio.hpp>  // boost::asio::ip::host_name();
+#include <boost/json/src.hpp>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <print>
+#include <string>
+#include <system_error>
+
+[[nodiscard]] static auto
+get_username() -> std::tuple<std::string, std::error_code> {
+  static constexpr auto username_maxsize = 128;
+  char buf[username_maxsize];
+  if (getlogin_r(buf, username_maxsize))
+    return {std::string(), std::make_error_code(std::errc(errno))};
+  return {std::string(buf), {}};
+}
+
+[[nodiscard]] static auto
+get_time_as_string() -> std::string {
+  const auto now{std::chrono::system_clock::now()};
+  const std::chrono::year_month_day ymd{
+    std::chrono::floor<std::chrono::days>(now)};
+  const std::chrono::hh_mm_ss hms{
+    std::chrono::floor<std::chrono::seconds>(now) -
+    std::chrono::floor<std::chrono::days>(now)};
+  return std::format("{:%F} {:%T}", ymd, hms);
+}
+
+[[nodiscard]] auto
+methylome_metadata::init(const std::string &index_filename,
+                         const std::string &methylome_filename)
+  -> std::tuple<methylome_metadata, std::error_code> {
+  std::error_code err;
+  const auto index_hash = get_adler(index_filename, err);
+  if (err)
+    return {{}, err};
+
+  const auto methylome_hash = get_adler(methylome_filename, err);
+  if (err)
+    return {{}, err};
+
+  boost::system::error_code boost_err;
+  const auto host = boost::asio::ip::host_name(boost_err);
+  if (boost_err)
+    return {{}, err};
+
+  const std::string assembly = get_assembly_from_filename(index_filename, err);
+  if (err)
+    return {{}, err};
+  const auto n_cpgs_from_file = methylome::get_n_cpgs_from_file(index_filename);
+
+  std::string username;
+  std::tie(username, err) = get_username();
+
+  return {methylome_metadata{VERSION, host, username, get_time_as_string(),
+                             methylome_hash, index_hash, assembly,
+                             n_cpgs_from_file},
+          err};
+}
+
+[[nodiscard]] auto
+methylome_metadata::read(const std::string &json_filename)
+  -> std::tuple<methylome_metadata, std::error_code> {
+
+  std::ifstream in(json_filename);
+  if (!in)
+    return {methylome_metadata{}, std::make_error_code(std::errc(errno))};
+
+  std::error_code ec;
+  const auto filesize = std::filesystem::file_size(json_filename, ec);
+  if (ec)
+    return {methylome_metadata{}, ec};
+
+  std::string payload(filesize, '\0');
+  if (!in.read(payload.data(), filesize))
+    return {{}, std::make_error_code(std::errc(errno))};
+
+  methylome_metadata mm;
+  boost::json::parse_into(mm, payload, ec);
+  if (ec)
+    return {methylome_metadata{},
+            methylome_metadata_error::failure_parsing_json};
+
+  return {mm, methylome_metadata_error::ok};
+}
+
+auto
+methylome_metadata::write(const methylome_metadata &mm,
+                          const std::string &json_filename) -> std::error_code {
+  std::ofstream out(json_filename);
+  if (!out)
+    return std::make_error_code(std::errc(errno));
+  if (!(out << boost::json::value_from(mm)))
+    return std::make_error_code(std::errc(errno));
+  return {};
+}
+
+auto
+methylome_metadata::tostring() const -> std::string {
+  return std::format("version: {}\n"
+                     "host: {}\n"
+                     "user: {}\n"
+                     "creation_time: \"{}\"\n"
+                     "methylome_hash: {}\n"
+                     "index_hash: {}\n"
+                     "assembly: {}\n"
+                     "n_cpgs: {}",
+                     version, host, user, creation_time, methylome_hash,
+                     index_hash, assembly, n_cpgs);
+}

--- a/src/methylome_metadata.cpp
+++ b/src/methylome_metadata.cpp
@@ -150,3 +150,9 @@ methylome_metadata::tostring() const -> std::string {
                      version, host, user, creation_time, methylome_hash,
                      index_hash, assembly, n_cpgs);
 }
+
+auto
+get_default_methylome_metadata_filename(const std::string &methfile)
+  -> std::string {
+  return std::format("{}.json", methfile);
+}

--- a/src/methylome_metadata.cpp
+++ b/src/methylome_metadata.cpp
@@ -89,7 +89,8 @@ methylome_metadata::init(
   const std::string assembly = get_assembly_from_filename(index_filename, err);
   if (err)
     return {{}, err};
-  const auto n_cpgs_from_file = methylome::get_n_cpgs_from_file(index_filename);
+  const auto n_cpgs_from_file =
+    methylome::get_n_cpgs_from_file(methylome_filename);
 
   std::string username;
   std::tie(username, err) = get_username();

--- a/src/methylome_metadata.hpp
+++ b/src/methylome_metadata.hpp
@@ -1,0 +1,125 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_METHYLOME_METADATA_HPP_
+#define SRC_METHYLOME_METADATA_HPP_
+
+#include "utilities.hpp"
+
+#include <boost/describe.hpp>  // for BOOST_DESCRIBE_STRUCT
+
+#include <format>
+#include <system_error>
+
+enum class methylome_metadata_error : std::uint32_t {
+  ok = 0,
+  version_not_found = 1,
+  host_not_found = 2,
+  user_not_found = 3,
+  creation_time_not_found = 4,
+  methylome_hash_not_found = 5,
+  index_hash_not_found = 6,
+  assembly_not_found = 7,
+  n_cpgs_not_found = 8,
+  failure_parsing_json = 9,
+};
+
+// register methylome_metadata_error as error code enum
+template <>
+struct std::is_error_code_enum<methylome_metadata_error>
+  : public std::true_type {};
+
+// category to provide text descriptions
+struct methylome_metadata_error_category : std::error_category {
+  const char *name() const noexcept override {
+    return "methylome_metadata_error";
+  }
+  std::string message(int code) const override {
+    using std::string_literals::operator""s;
+    // clang-format off
+    switch (code) {
+    case 0: return "ok"s;
+    case 1: return "verion not found"s;
+    case 2: return "host not found"s;
+    case 3: return "user not found"s;
+    case 4: return "creation_time not found"s;
+    case 5: return "methylome_hash not found"s;
+    case 6: return "index_hash not found"s;
+    case 7: return "assembly not found"s;
+    case 8: return "n_cpgs not found"s;
+    case 9: return "failure parsing methylome metadata json"s;
+      // clang-format on
+    }
+    std::unreachable();  // hopefully this is unreacheable
+  }
+};
+
+inline std::error_code
+make_error_code(methylome_metadata_error e) {
+  static auto category = methylome_metadata_error_category{};
+  return std::error_code(std::to_underlying(e), category);
+}
+
+struct methylome_metadata {
+  static constexpr auto filename_extension{"m16.yaml"};
+  std::string version{};
+  std::string host{};
+  std::string user{};
+  std::string creation_time{};
+  std::uint64_t methylome_hash{};
+  std::uint64_t index_hash{};
+  std::string assembly{};
+  std::uint32_t n_cpgs{};
+  static auto init(const std::string &index_filename,
+                   const std::string &methylome_filename)
+    -> std::tuple<methylome_metadata, std::error_code>;
+  static auto read(const std::string &json_filename)
+    -> std::tuple<methylome_metadata, std::error_code>;
+  static auto write(const methylome_metadata &mm,
+                    const std::string &json_filename) -> std::error_code;
+  auto tostring() const -> std::string;
+};
+
+// clang-format off
+BOOST_DESCRIBE_STRUCT(methylome_metadata, (),
+(
+ version,
+ host,
+ user,
+ creation_time,
+ methylome_hash,
+ index_hash,
+ assembly,
+ n_cpgs
+))
+// clang-format on
+
+template <>
+struct std::formatter<methylome_metadata> : std::formatter<std::string> {
+  auto format(const methylome_metadata &mm, std::format_context &ctx) const {
+    return std::formatter<std::string>::format(std::format("{}", mm.tostring()),
+                                               ctx);
+  }
+};
+
+#endif  // SRC_METHYLOME_METADATA_HPP_

--- a/src/methylome_metadata.hpp
+++ b/src/methylome_metadata.hpp
@@ -24,12 +24,15 @@
 #ifndef SRC_METHYLOME_METADATA_HPP_
 #define SRC_METHYLOME_METADATA_HPP_
 
-#include "utilities.hpp"
+#include "utilities.hpp"  // get_adler
 
 #include <boost/describe.hpp>  // for BOOST_DESCRIBE_STRUCT
 
+#include <cstdint>
 #include <format>
+#include <string>
 #include <system_error>
+#include <tuple>
 
 enum class methylome_metadata_error : std::uint32_t {
   ok = 0,
@@ -81,23 +84,27 @@ make_error_code(methylome_metadata_error e) {
 }
 
 struct methylome_metadata {
-  static constexpr auto filename_extension{"m16.yaml"};
-  std::string version{};
-  std::string host{};
-  std::string user{};
-  std::string creation_time{};
+  static constexpr auto filename_extension{"m16.json"};
+  std::string version;
+  std::string host;
+  std::string user;
+  std::string creation_time;
   std::uint64_t methylome_hash{};
   std::uint64_t index_hash{};
-  std::string assembly{};
+  std::string assembly;
   std::uint32_t n_cpgs{};
-  static auto init(const std::string &index_filename,
-                   const std::string &methylome_filename)
+  bool is_compressed{};
+  // ADS: (todo) think of a better way to get "compression" status
+  [[nodiscard]] static auto init(const std::string &index_filename,
+                                 const std::string &methylome_filename,
+                                 const bool is_compressed)
     -> std::tuple<methylome_metadata, std::error_code>;
-  static auto read(const std::string &json_filename)
+  [[nodiscard]] static auto read(const std::string &json_filename)
     -> std::tuple<methylome_metadata, std::error_code>;
-  static auto write(const methylome_metadata &mm,
-                    const std::string &json_filename) -> std::error_code;
-  auto tostring() const -> std::string;
+  [[nodiscard]] static auto
+  write(const methylome_metadata &mm,
+        const std::string &json_filename) -> std::error_code;
+  [[nodiscard]] auto tostring() const -> std::string;
 };
 
 // clang-format off
@@ -110,7 +117,8 @@ BOOST_DESCRIBE_STRUCT(methylome_metadata, (),
  methylome_hash,
  index_hash,
  assembly,
- n_cpgs
+ n_cpgs,
+ is_compressed
 ))
 // clang-format on
 
@@ -121,5 +129,9 @@ struct std::formatter<methylome_metadata> : std::formatter<std::string> {
                                                ctx);
   }
 };
+
+auto
+get_default_methylome_metadata_filename(const std::string &methfile)
+  -> std::string;
 
 #endif  // SRC_METHYLOME_METADATA_HPP_

--- a/src/methylome_set.cpp
+++ b/src/methylome_set.cpp
@@ -37,6 +37,10 @@
 #include <unordered_map>
 #include <utility>  // std::move
 
+// DEBUG
+#include <iostream>
+#include <print>
+
 [[nodiscard]] static auto
 is_valid_accession(const std::string &accession) -> bool {
   static constexpr auto experiment_ptrn = R"(^(D|E|S)RX\d+$)";
@@ -46,51 +50,84 @@ is_valid_accession(const std::string &accession) -> bool {
 
 [[nodiscard]] auto
 methylome_set::get_methylome(const std::string &accession)
-  -> std::tuple<std::shared_ptr<methylome>, std::error_code> {
-  static constexpr auto methylome_filename_format = "{}/{}.{}";
+  -> std::tuple<std::shared_ptr<methylome>, std::shared_ptr<methylome_metadata>,
+                std::error_code> {
+  static constexpr auto filename_format = "{}/{}.{}";
 
   if (!is_valid_accession(accession))
-    return {nullptr, methylome_set_code::invalid_accession};
+    return {nullptr, nullptr, methylome_set_code::invalid_accession};
 
-  std::unordered_map<std::string, std::shared_ptr<methylome>>::const_iterator
-    meth{};
+  // clang-format off
+  std::unordered_map<std::string, std::shared_ptr<methylome>>::const_iterator meth{};
+  std::unordered_map<std::string, std::shared_ptr<methylome_metadata>>::const_iterator meta{};
+  // clang-format on
 
   std::scoped_lock lock{mtx};
 
   // check if methylome is loaded
-  const auto acc_meth_itr = accession_to_methylome.find(accession);
-  if (acc_meth_itr == std::cend(accession_to_methylome)) {
-    const auto filename =
-      std::format(methylome_filename_format, methylome_directory, accession,
-                  methylome_extension);
-    if (!std::filesystem::exists(filename))
-      return {nullptr, methylome_set_code::methylome_file_not_found};
+  const auto meth_itr = accession_to_methylome.find(accession);
+  const auto meta_itr = accession_to_methylome_metadata.find(accession);
+  if (meth_itr == std::cend(accession_to_methylome) &&
+      meta_itr == std::cend(accession_to_methylome_metadata)) {
+    const auto methylome_filename =
+      std::format(filename_format, methylome_directory, accession,
+                  methylome::filename_extension);
+    if (!std::filesystem::exists(methylome_filename))
+      return {nullptr, nullptr, methylome_set_code::methylome_file_not_found};
+
+    const auto metadata_filename =
+      std::format(filename_format, methylome_directory, accession,
+                  methylome_metadata::filename_extension);
+    std::println(std::cerr, "{}", metadata_filename);
+    if (!std::filesystem::exists(metadata_filename))
+      return {nullptr, nullptr,
+              methylome_set_code::methylome_metadata_file_not_found};
 
     const std::string to_eject = accessions.push(accession);
     if (!to_eject.empty()) {
-      const auto to_eject_itr = accession_to_methylome.find(to_eject);
-      if (to_eject_itr == std::cend(accession_to_methylome))
-        return {nullptr, methylome_set_code::error_updating_live_methylomes};
+      const auto to_eject_meth_itr = accession_to_methylome.find(to_eject);
+      const auto to_eject_meta_itr =
+        accession_to_methylome_metadata.find(to_eject);
+      if (to_eject_meth_itr == std::cend(accession_to_methylome) ||
+          to_eject_meta_itr == std::cend(accession_to_methylome_metadata))
+        return {nullptr, nullptr,
+                methylome_set_code::error_updating_live_methylomes};
 
-      accession_to_methylome.erase(to_eject_itr);
+      accession_to_methylome.erase(to_eject_meth_itr);
+      accession_to_methylome_metadata.erase(to_eject_meta_itr);
     }
 
     // ADS: get an error code from methylome::read and use it
     methylome m{};
-    if ([[maybe_unused]] const auto ec = m.read(filename))
-      return {nullptr, methylome_set_code::error_reading_methylome_file};
+    if ([[maybe_unused]] const auto ec = m.read(methylome_filename))
+      return {nullptr, nullptr,
+              methylome_set_code::error_reading_methylome_file};
+
+    const auto [m_meta, ec] = methylome_metadata::read(metadata_filename);
+    if (ec)
+      return {nullptr, nullptr,
+              methylome_set_code::error_reading_methylome_file};
 
     bool insertion_happened{false};
     std::tie(meth, insertion_happened) = accession_to_methylome.emplace(
       accession, std::make_shared<methylome>(std::move(m)));
     if (!insertion_happened)
-      return {nullptr, methylome_set_code::methylome_already_live};
+      return {nullptr, nullptr, methylome_set_code::methylome_already_live};
+
+    std::tie(meta, insertion_happened) =
+      accession_to_methylome_metadata.emplace(
+        accession, std::make_shared<methylome_metadata>(std::move(m_meta)));
+    if (!insertion_happened)
+      return {nullptr, nullptr, methylome_set_code::methylome_already_live};
   }
-  else
-    meth = acc_meth_itr;  // already loaded
+  else if (meth_itr == std::cend(accession_to_methylome) ||
+           meta_itr == std::cend(accession_to_methylome_metadata)) {
+    return {nullptr, nullptr, methylome_set_code::methylome_already_live};
+  }
+  else {
+    meth = meth_itr;  // already loaded
+    meta = meta_itr;
+  }
 
-  // ADS TODO: use this as error condition
-  n_total_cpgs = std::size(meth->second->cpgs);
-
-  return {meth->second, methylome_set_code::ok};
+  return {meth->second, meta->second, methylome_set_code::ok};
 }

--- a/src/methylome_set.cpp
+++ b/src/methylome_set.cpp
@@ -79,7 +79,6 @@ methylome_set::get_methylome(const std::string &accession)
     const auto metadata_filename =
       std::format(filename_format, methylome_directory, accession,
                   methylome_metadata::filename_extension);
-    std::println(std::cerr, "{}", metadata_filename);
     if (!std::filesystem::exists(metadata_filename))
       return {nullptr, nullptr,
               methylome_set_code::methylome_metadata_file_not_found};

--- a/src/methylome_set.hpp
+++ b/src/methylome_set.hpp
@@ -25,6 +25,7 @@
 #define SRC_METHYLOME_SET_HPP_
 
 #include "methylome.hpp"
+#include "methylome_metadata.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -73,21 +74,16 @@ struct methylome_set {
 
   methylome_set(const std::uint32_t max_live_methylomes,
                 const std::string &methylome_directory) :
-    n_total_cpgs{}, max_live_methylomes{max_live_methylomes},
+    max_live_methylomes{max_live_methylomes},
     methylome_directory{methylome_directory}, accessions{max_live_methylomes} {}
 
   [[nodiscard]] auto get_methylome(const std::string &accession)
-    -> std::tuple<std::shared_ptr<methylome>, std::error_code>;
-
-  [[nodiscard]] auto get_n_total_cpgs() const -> std::uint32_t {
-    return n_total_cpgs;
-  }
+    -> std::tuple<std::shared_ptr<methylome>,
+                  std::shared_ptr<methylome_metadata>, std::error_code>;
 
   static constexpr std::uint32_t default_max_live_methylomes{128};
-  static constexpr auto methylome_extension{"mc16"};
 
   std::mutex mtx;
-  std::uint32_t n_total_cpgs{};
   std::uint32_t max_live_methylomes{};
   std::string methylome_directory;
 
@@ -95,6 +91,8 @@ struct methylome_set {
 
   std::unordered_map<std::string, std::shared_ptr<methylome>>
     accession_to_methylome;
+  std::unordered_map<std::string, std::shared_ptr<methylome_metadata>>
+    accession_to_methylome_metadata;
 };
 
 #endif  // SRC_METHYLOME_SET_HPP_

--- a/src/mxe_error.hpp
+++ b/src/mxe_error.hpp
@@ -56,25 +56,17 @@ struct request_error_category : std::error_category {
   const char *name() const noexcept override { return "request_error"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "header parse error accession"s;
-    case 2:
-      return "header parse error methylome size"s;
-    case 3:
-      return "header parse error request type"s;
-    case 4:
-      return "lookup parse error n_intervals"s;
-    case 5:
-      return "lookup error reading offsets"s;
-    case 6:
-      return "lookup error offsets"s;
-    case 7:
-      return "bins error assembly"s;
-    case 8:
-      return "bins error bin size"s;
+    case 0: return "ok"s;
+    case 1: return "header parse error accession"s;
+    case 2: return "header parse error methylome size"s;
+    case 3: return "header parse error request type"s;
+    case 4: return "lookup parse error n_intervals"s;
+    case 5: return "lookup error reading offsets"s;
+    case 6: return "lookup error offsets"s;
+    case 7: return "bins error assembly"s;
+    case 8: return "bins error bin size"s;
     }
     std::unreachable();  // hopefully this is unreacheable
   }
@@ -108,24 +100,18 @@ struct server_response_category : std::error_category {
   const char *name() const noexcept override { return "server_response"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "invalid accession"s;
-    case 2:
-      return "invalid request type"s;
-    case 3:
-      return "invalid methylome size"s;
-    case 4:
-      return "methylome not found"s;
-    case 5:
-      return "index not found"s;
-    case 6:
-      return "server failure"s;
-    case 7:
-      return "bad request"s;
+    case 0: return "ok"s;
+    case 1: return "invalid accession"s;
+    case 2: return "invalid request type"s;
+    case 3: return "invalid methylome size"s;
+    case 4: return "methylome not found"s;
+    case 5: return "index not found"s;
+    case 6: return "server failure"s;
+    case 7: return "bad request"s;
     }
+    // clang-format on
     std::unreachable();  // hopefully
   }
 };
@@ -160,24 +146,18 @@ struct methylome_set_category : std::error_category {
   const char *name() const noexcept override { return "methylome_set"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "invalid accession"s;
-    case 2:
-      return "methylome file not found"s;
-    case 3:
-      return "error updating live methylomes"s;
-    case 4:
-      return "error reading methylome file"s;
-    case 5:
-      return "methylome already live"s;
-    case 6:
-      return "methylome metadata file not found"s;
-    case 7:
-      return "error reading methylome metadata file"s;
+    case 0: return "ok"s;
+    case 1: return "invalid accession"s;
+    case 2: return "methylome file not found"s;
+    case 3: return "error updating live methylomes"s;
+    case 4: return "error reading methylome file"s;
+    case 5: return "methylome already live"s;
+    case 6: return "methylome metadata file not found"s;
+    case 7: return "error reading methylome metadata file"s;
     }
+    // clang-format on
     std::unreachable();  // hopefully
   }
 };
@@ -213,26 +193,19 @@ struct methylome_category : std::error_category {
   const char *name() const noexcept override { return "methylome"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "error reading methylome header"s;
-    case 2:
-      return "invalid methylome header"s;
-    case 3:
-      return "error reading methylome"s;
-    case 4:
-      return "error decompressing methylome"s;
-    case 5:
-      return "error compressing methylome"s;
-    case 6:
-      return "error writing methylome header"s;
-    case 7:
-      return "error writing methylome"s;
-    case 8:
-      return "incorrect methylome size"s;
+    case 0: return "ok"s;
+    case 1: return "error reading methylome header"s;
+    case 2: return "invalid methylome header"s;
+    case 3: return "error reading methylome"s;
+    case 4: return "error decompressing methylome"s;
+    case 5: return "error compressing methylome"s;
+    case 6: return "error writing methylome header"s;
+    case 7: return "error writing methylome"s;
+    case 8: return "incorrect methylome size"s;
     }
+    // clang-format on
     std::unreachable();  // hopefully
   }
 };
@@ -264,16 +237,14 @@ struct genomic_interval_category : std::error_category {
   const char *name() const noexcept override { return "genomic_interval"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "error parsing BED line"s;
-    case 2:
-      return "chrom name not found in index"s;
-    case 3:
-      return "interval past chrom end in index"s;
+    case 0: return "ok"s;
+    case 1: return "error parsing BED line"s;
+    case 2: return "chrom name not found in index"s;
+    case 3: return "interval past chrom end in index"s;
     }
+    // clang-format on
     std::unreachable();  // hopefully
   }
 };
@@ -326,20 +297,15 @@ make_error_code(cpg_index_code e) {
   return std::error_code(std::to_underlying(e), category);
 }
 
-/*
-  print std::error_code messages
- */
+// print std::error_code messages
 template <>
 struct std::formatter<std::error_code> : std::formatter<std::string> {
   auto format(const std::error_code &e, std::format_context &ctx) const {
-    return std::formatter<std::string>::format(std::format("{}", e.message()),
-                                               ctx);
+    return std::formatter<std::string>::format(e.message(), ctx);
   }
 };
 
-/*
-  print boost::system::error_code messages
- */
+// print boost::system::error_code messages
 template <>
 struct std::formatter<boost::system::error_code> : std::formatter<std::string> {
   auto format(const boost::system::error_code &e,

--- a/src/mxe_error.hpp
+++ b/src/mxe_error.hpp
@@ -41,9 +41,11 @@ enum class request_error : std::uint32_t {
   lookup_parse_error_n_intervals = 4,
   lookup_error_reading_offsets = 5,
   lookup_error_offsets = 6,
+  bins_error_assembly = 7,
+  bins_error_bin_size = 8,
 };
 
-static constexpr std::uint32_t request_error_n = 7;
+static constexpr std::uint32_t request_error_n = 9;
 
 // register request_error as error code enum
 template <>
@@ -69,6 +71,10 @@ struct request_error_category : std::error_category {
       return "lookup error reading offsets"s;
     case 6:
       return "lookup error offsets"s;
+    case 7:
+      return "bins error assembly"s;
+    case 8:
+      return "bins error bin size"s;
     }
     std::unreachable();  // hopefully this is unreacheable
   }
@@ -139,9 +145,11 @@ enum class methylome_set_code : std::uint32_t {
   error_updating_live_methylomes = 3,
   error_reading_methylome_file = 4,
   methylome_already_live = 5,
+  methylome_metadata_file_not_found = 6,
+  error_reading_metadata_file = 7,
 };
 
-static constexpr std::uint32_t methylome_set_code_n = 6;
+static constexpr std::uint32_t methylome_set_code_n = 8;
 
 // register methylome_set_code as error code enum
 template <>
@@ -165,6 +173,10 @@ struct methylome_set_category : std::error_category {
       return "error reading methylome file"s;
     case 5:
       return "methylome already live"s;
+    case 6:
+      return "methylome metadata file not found"s;
+    case 7:
+      return "error reading methylome metadata file"s;
     }
     std::unreachable();  // hopefully
   }
@@ -294,20 +306,16 @@ struct cpg_index_category : std::error_category {
   const char *name() const noexcept override { return "cpg_index"; }
   std::string message(int code) const override {
     using std::string_literals::operator""s;
+    // clang-format off
     switch (code) {
-    case 0:
-      return "ok"s;
-    case 1:
-      return "wrong identifier in header"s;
-    case 2:
-      return "error parsing index header line"s;
-    case 3:
-      return "failure reading index header"s;
-    case 4:
-      return "failure reading index body"s;
-    case 5:
-      return "inconsistent chromosome sizes"s;
+    case 0: return "ok"s;
+    case 1: return "wrong identifier in header"s;
+    case 2: return "error parsing index header line"s;
+    case 3: return "failure reading index header"s;
+    case 4: return "failure reading index body"s;
+    case 5: return "inconsistent chromosome sizes"s;
     }
+    // clang-format on
     std::unreachable();  // hopefully
   }
 };

--- a/src/request.hpp
+++ b/src/request.hpp
@@ -52,6 +52,14 @@ struct request_header {
   auto is_valid_type() const -> bool {
     return rq_type < request_type::n_request_types;
   }
+  auto is_intervals_request() const -> bool {
+    return rq_type == request_type::counts ||
+           rq_type == request_type::counts_cov;
+  }
+  auto is_bins_request() const -> bool {
+    return rq_type == request_type::bin_counts ||
+           rq_type == request_type::bin_counts_cov;
+  }
 };
 
 template <>
@@ -110,5 +118,18 @@ to_chars(char *first, char *last, const request &req) -> mxe_to_chars_result;
 auto
 from_chars(const char *first, const char *last,
            request &req) -> mxe_from_chars_result;
+
+struct bins_request {
+  std::uint32_t bin_size{};
+  auto summary() const -> std::string;
+};
+
+auto
+to_chars(char *first, char *last,
+         const bins_request &req) -> mxe_to_chars_result;
+
+auto
+from_chars(const char *first, const char *last,
+           bins_request &req) -> mxe_from_chars_result;
 
 #endif  // SRC_REQUEST_HPP_

--- a/src/request_handler.cpp
+++ b/src/request_handler.cpp
@@ -22,13 +22,13 @@
  */
 
 #include "request_handler.hpp"
+
+#include "logger.hpp"
 #include "methylome.hpp"
+#include "mxe_error.hpp"
 #include "request.hpp"
 #include "response.hpp"
 #include "utilities.hpp"
-
-#include "logger.hpp"
-#include "mxe_error.hpp"
 
 #include <chrono>
 #include <cstdint>
@@ -149,5 +149,9 @@ request_handler::handle_get_counts(const request_header &req_hdr,
     resp_data =
       counts_to_payload(meth->get_counts_cov(req.offsets), req_hdr, req);
     return;
+    // case request_header::request_type::bin_counts:
+    //   resp_data =
+    //     counts_to_payload(meth->get_bins(req.offsets, index), req_hdr, req);
+    //   return;
   }
 }

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -29,6 +29,7 @@
 #include "request.hpp"
 #include "response.hpp"
 
+#include <cstdint>
 #include <string>
 
 // handles all incoming requests
@@ -52,6 +53,10 @@ struct request_handler {
   auto handle_get_bins(const request_header &req_hdr, const bins_request &req,
                        response_header &resp_hdr,
                        response_payload &resp) -> void;
+
+  auto add_response_size_for_bins(const request_header &req_hdr,
+                                  const bins_request &req,
+                                  response_header &resp_hdr) -> void;
 
   std::string methylome_dir;   // dir of available methylomes
   std::string index_file_dir;  // dir of cpg index files

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -39,16 +39,15 @@ struct request_handler {
   explicit request_handler(const std::string &methylome_dir,
                            const std::string &index_file_dir,
                            const std::uint32_t max_live_methylomes) :
-    methylome_dir{methylome_dir},
-    index_file_dir{index_file_dir}, ms(max_live_methylomes, methylome_dir),
-    indexes(index_file_dir) {}
+    methylome_dir{methylome_dir}, index_file_dir{index_file_dir},
+    ms(max_live_methylomes, methylome_dir), indexes(index_file_dir) {}
 
-  auto handle_header(const request_header &req_hdr, response_header &resp_hdr)
-    -> void;
+  auto handle_header(const request_header &req_hdr,
+                     response_header &resp_hdr) -> void;
 
   auto handle_get_counts(const request_header &req_hdr, const request &req,
-                         response_header &resp_hdr, response_payload &resp)
-    -> void;
+                         response_header &resp_hdr,
+                         response_payload &resp) -> void;
 
   std::string methylome_dir;   // dir of available methylomes
   std::string index_file_dir;  // dir of cpg index files

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -24,9 +24,8 @@
 #ifndef SRC_REQUEST_HANDLER_HPP_
 #define SRC_REQUEST_HANDLER_HPP_
 
+#include "cpg_index_set.hpp"
 #include "methylome_set.hpp"
-
-#include "logger.hpp"
 #include "request.hpp"
 #include "response.hpp"
 
@@ -38,21 +37,23 @@ struct request_handler {
   request_handler &operator=(const request_handler &) = delete;
 
   explicit request_handler(const std::string &methylome_dir,
+                           const std::string &index_file_dir,
                            const std::uint32_t max_live_methylomes) :
-    methylome_dir{methylome_dir}, ms(max_live_methylomes, methylome_dir) {}
+    methylome_dir{methylome_dir},
+    index_file_dir{index_file_dir}, ms(max_live_methylomes, methylome_dir),
+    indexes(index_file_dir) {}
 
-  auto handle_header(const request_header &req_hdr,
-                     response_header &resp_hdr) -> void;
+  auto handle_header(const request_header &req_hdr, response_header &resp_hdr)
+    -> void;
 
   auto handle_get_counts(const request_header &req_hdr, const request &req,
-                         response_header &resp_hdr,
-                         response_payload &resp) -> void;
+                         response_header &resp_hdr, response_payload &resp)
+    -> void;
 
   std::string methylome_dir;   // dir of available methylomes
-  std::string cpg_index_file;  // file with cpg_index
+  std::string index_file_dir;  // dir of cpg index files
   methylome_set ms;
-  cpg_index index;
-  bool verbose{};
+  cpg_index_set indexes;
 };
 
 #endif  // SRC_REQUEST_HANDLER_HPP_

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -49,6 +49,10 @@ struct request_handler {
                          response_header &resp_hdr,
                          response_payload &resp) -> void;
 
+  auto handle_get_bins(const request_header &req_hdr, const bins_request &req,
+                       response_header &resp_hdr,
+                       response_payload &resp) -> void;
+
   std::string methylome_dir;   // dir of available methylomes
   std::string index_file_dir;  // dir of cpg index files
   methylome_set ms;

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -42,7 +42,7 @@ auto
 to_chars(char *first, [[maybe_unused]] char *last,
          const response_header &hdr) -> mxe_to_chars_result {
   // ADS: use to_chars here
-  const string s = format("{}\t{}\n", hdr.status.value(), hdr.methylome_size);
+  const string s = format("{}\t{}\n", hdr.status.value(), hdr.response_size);
   assert(ssize(s) < std::distance(first, last));
   auto data_end = rg::copy(s, first);  // in_out_result
   return {data_end.out, request_error::ok};
@@ -72,7 +72,7 @@ from_chars(const char *first, const char *last,
 
   // methylome size
   {
-    const auto [ptr, ec] = std::from_chars(cursor, last, hdr.methylome_size);
+    const auto [ptr, ec] = std::from_chars(cursor, last, hdr.response_size);
     if (ec != std::errc{})
       return {ptr, server_response_code::server_failure};
     cursor = ptr;
@@ -100,6 +100,6 @@ parse(const array<char, response_buf_size> &buf,
 
 auto
 response_header::summary() const -> string {
-  static constexpr auto fmt = R"({{"{}": "{}", "methylome_size": {}}})";
-  return std::format(fmt, status.category().name(), status, methylome_size);
+  static constexpr auto fmt = R"({{"{}": "{}", "response_size": {}}})";
+  return std::format(fmt, status.category().name(), status, response_size);
 }

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -41,7 +41,7 @@ typedef std::array<char, response_buf_size> response_header_buffer;
 
 struct response_header {
   std::error_code status{make_error_code(server_response_code::ok)};
-  std::uint32_t methylome_size{};
+  std::uint32_t response_size{};
 
   // ADS: doing the strange stuff below for cpplint...
   auto error() const -> bool { return (status) ? true : false; }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -97,6 +97,7 @@ write_pid_to_file(std::error_code &ec) -> void {
 
 server::server(const string &address, const string &port,
                const uint32_t n_threads, const string &methylome_dir,
+               const string &cpg_index_file_dir,
                const uint32_t max_live_methylomes, logger &lgr) :
   n_threads{n_threads},
 #if defined(SIGQUIT)
@@ -104,7 +105,8 @@ server::server(const string &address, const string &port,
 #else
   signals(ioc, SIGINT, SIGTERM),
 #endif
-  acceptor(ioc), handler(methylome_dir, max_live_methylomes), lgr{lgr} {
+  acceptor(ioc),
+  handler(methylome_dir, cpg_index_file_dir, max_live_methylomes), lgr{lgr} {
   // io_context ios uses default constructor
 
   do_await_stop();  // start waiting for signals
@@ -160,6 +162,7 @@ server::server(const string &address, const string &port,
 
 server::server(const string &address, const string &port,
                const uint32_t n_threads, const string &methylome_dir,
+               const string &cpg_index_file_dir,
                const uint32_t max_live_methylomes, logger &lgr,
                std::error_code &ec) :
   n_threads{n_threads},
@@ -169,7 +172,8 @@ server::server(const string &address, const string &port,
 #else
   signals(ioc, SIGINT, SIGTERM),
 #endif
-  acceptor(ioc), handler(methylome_dir, max_live_methylomes), lgr{lgr} {
+  acceptor(ioc),
+  handler(methylome_dir, cpg_index_file_dir, max_live_methylomes), lgr{lgr} {
   // io_context ioc uses default constructor
 
   do_daemon_await_stop();  // signals setup; start waiting for them

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -41,11 +41,13 @@ struct server {
   explicit server(const std::string &address, const std::string &port,
                   const std::uint32_t n_threads,
                   const std::string &methylome_dir,
+                  const std::string &index_file_dir,
                   const std::uint32_t max_live_methylomes, logger &lgr);
 
   explicit server(const std::string &address, const std::string &port,
                   const std::uint32_t n_threads,
                   const std::string &methylome_dir,
+                  const std::string &index_file_dir,
                   const std::uint32_t max_live_methylomes, logger &lgr,
                   std::error_code &ec);
 

--- a/src/server_interface.cpp
+++ b/src/server_interface.cpp
@@ -119,8 +119,8 @@ struct server_interface_argset : argset_base<server_interface_argset> {
     });
   }
 
-  [[nodiscard]] auto set_common_opts_impl()
-    -> boost::program_options::options_description {
+  [[nodiscard]] auto
+  set_common_opts_impl() -> boost::program_options::options_description {
     namespace po = boost::program_options;
     using po::value;
     po::options_description opts("Command line or config file");

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -30,7 +30,7 @@
 
 #include "cpg_index.hpp"
 #include "genomic_interval.hpp"
-#include "methylome.hpp"
+#include "methylome_results_types.hpp"  // counts_res and counts_res_cov
 
 #include <algorithm>
 #include <cassert>
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -272,9 +273,6 @@ get_adler(const std::string &filename, std::error_code &ec) -> std::uint64_t {
   return adler32_z(0, reinterpret_cast<std::uint8_t *>(buf.data()), filesize);
 }
 
-/*
-  print std::filesystem::path
- */
 template <>
 struct std::formatter<std::filesystem::path> : std::formatter<std::string> {
   auto format(const std::filesystem::path &p, std::format_context &ctx) const {

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -33,6 +33,7 @@
 #include "methylome.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
@@ -163,8 +164,55 @@ write_bedgraph(std::ostream &out, const cpg_index &index,
 
 auto
 write_bins(std::ostream &out, const std::uint32_t bin_size,
-           const cpg_index &index,
-           const std::vector<counts_res_cov> &results) -> std::error_code;
+           const cpg_index &index, const auto &results) -> std::error_code {
+  static constexpr auto buf_size{512};
+  static constexpr auto delim{'\t'};
+
+  using counts_res_type =
+    typename std::remove_cvref_t<decltype(results)>::value_type;
+
+  std::array<char, buf_size> buf{};
+  const auto buf_beg = buf.data();
+  const auto buf_end = buf.data() + buf_size;
+
+  auto res = std::cbegin(results);
+
+  const auto zipped = std::views::zip(index.chrom_size, index.chrom_order);
+  for (const auto [chrom_size, chrom_name] : zipped) {
+    std::ranges::copy(chrom_name, buf_beg);
+    buf[size(chrom_name)] = delim;
+    for (std::uint32_t bin_beg = 0; bin_beg < chrom_size; bin_beg += bin_size) {
+      const auto bin_end = std::min(bin_beg + bin_size, chrom_size);
+      std::to_chars_result tcr{buf_beg + std::size(chrom_name) + 1,
+                               std::errc()};
+#if defined(__GNUG__) and not defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wstringop-overflow=0"
+#endif
+      tcr = std::to_chars(tcr.ptr, buf_end, bin_beg);
+      *tcr.ptr++ = delim;
+      tcr = std::to_chars(tcr.ptr, buf_end, bin_end);
+      *tcr.ptr++ = delim;
+      tcr = std::to_chars(tcr.ptr, buf_end, res->n_meth);
+      *tcr.ptr++ = delim;
+      tcr = std::to_chars(tcr.ptr, buf_end, res->n_unmeth);
+      if constexpr (std::is_same<counts_res_type, counts_res_cov>::value) {
+        *tcr.ptr++ = delim;
+        tcr = std::to_chars(tcr.ptr, buf_end, res->n_covered);
+      }
+      *tcr.ptr++ = '\n';
+#if defined(__GNUG__) and not defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+      out.write(buf_beg, std::ranges::distance(buf_beg, tcr.ptr));
+      if (!out)
+        return std::make_error_code(std::errc(errno));
+      ++res;
+    }
+  }
+  assert(res == std::cend(results));
+  return {};
+}
 
 [[nodiscard]] inline auto
 duration(const auto start, const auto stop) {

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -172,18 +172,17 @@ write_bins(std::ostream &out, const std::uint32_t bin_size,
     typename std::remove_cvref_t<decltype(results)>::value_type;
 
   std::array<char, buf_size> buf{};
-  const auto buf_beg = buf.data();
   const auto buf_end = buf.data() + buf_size;
 
   auto res = std::cbegin(results);
 
   const auto zipped = std::views::zip(index.chrom_size, index.chrom_order);
   for (const auto [chrom_size, chrom_name] : zipped) {
-    std::ranges::copy(chrom_name, buf_beg);
+    std::ranges::copy(chrom_name, buf.data());
     buf[size(chrom_name)] = delim;
     for (std::uint32_t bin_beg = 0; bin_beg < chrom_size; bin_beg += bin_size) {
       const auto bin_end = std::min(bin_beg + bin_size, chrom_size);
-      std::to_chars_result tcr{buf_beg + std::size(chrom_name) + 1,
+      std::to_chars_result tcr{buf.data() + std::size(chrom_name) + 1,
                                std::errc()};
 #if defined(__GNUG__) and not defined(__clang__)
 #pragma GCC diagnostic push
@@ -204,7 +203,7 @@ write_bins(std::ostream &out, const std::uint32_t bin_size,
 #if defined(__GNUG__) and not defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-      out.write(buf_beg, std::ranges::distance(buf_beg, tcr.ptr));
+      out.write(buf.data(), std::ranges::distance(buf.data(), tcr.ptr));
       if (!out)
         return std::make_error_code(std::errc(errno));
       ++res;

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -86,7 +86,7 @@ zip_main(int argc, char *argv[]) -> int {
     return EXIT_FAILURE;
   }
 
-  if (metadata_output.empty())
+  if (metadata_input.empty())
     metadata_input = std::format("{}.json", methylome_input);
 
   if (metadata_output.empty())

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -22,9 +22,10 @@
  */
 
 #include "zip.hpp"
+
+#include "logger.hpp"
 #include "methylome.hpp"
 #include "mxe_error.hpp"
-#include "utilities.hpp"
 
 #include <boost/program_options.hpp>
 
@@ -32,111 +33,121 @@
 #include <iostream>
 #include <print>
 #include <string>
-
-using std::println;
-using std::string;
-
-using hr_clock = std::chrono::high_resolution_clock;
-
-namespace po = boost::program_options;
-using po::value;
+#include <tuple>
+#include <vector>
 
 auto
 zip_main(int argc, char *argv[]) -> int {
-  static const auto description = "zip";
+  static constexpr mxe_log_level default_log_level = mxe_log_level::info;
+  static constexpr auto command = "zip";
 
-  bool verbose{};
+  std::string methylome_input{};
+  std::string metadata_input{};
+  std::string methylome_output{};
+  std::string metadata_output{};
+  mxe_log_level log_level{};
   bool unzip{false};
 
-  uint32_t n_cpgs{};
+  namespace po = boost::program_options;
 
-  string input_file{};
-  string index_file{};
-  string output_file{};
-
-  po::options_description desc(description);
+  po::options_description desc(std::format("Usage: mxe {} [options]", command));
   // clang-format off
   desc.add_options()
     ("help,h", "produce help message")
-    ("input,i", value(&input_file)->required(), "input file")
-    ("output,o", value(&output_file)->required(),
+    ("input,i", po::value(&methylome_input)->required(), "input file")
+    ("output,o", po::value(&methylome_output)->required(),
      "output file")
     ("unzip,u", po::bool_switch(&unzip), "unzip the file")
-    ("index,x", value(&index_file), "can give number of cpgs needed to unzip")
-    ("n-cpgs,n", value(&n_cpgs), "number of cpgs needed to unzip")
-    ("verbose,v", po::bool_switch(&verbose), "print more run info")
+    ("meta", po::value(&metadata_input), "metadata input (defaults to input.json)")
+    ("meta-out", po::value(&metadata_output),
+     "metadata output (defaults to output.json)")
+    ("log-level,v", po::value(&log_level)->default_value(default_log_level),
+     "log level {debug,info,warning,error,critical}")
     ;
   // clang-format on
   try {
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
-    if (vm.count("help")) {
+    if (vm.count("help") || argc == 1) {
       desc.print(std::cout);
       return EXIT_SUCCESS;
     }
     po::notify(vm);
   }
   catch (po::error &e) {
-    println("{}", e.what());
+    std::println("{}", e.what());
     desc.print(std::cout);
     return EXIT_FAILURE;
   }
 
-  if (unzip && index_file.empty() && n_cpgs == 0) {
-    println(std::cerr, "Index file or number of cpgs needed to unzip");
+  auto &lgr = logger::instance(shared_from_cout(), command, log_level);
+  if (!lgr) {
+    std::println("Failure initializing logging: {}.", lgr.get_status());
     return EXIT_FAILURE;
   }
 
-  if (verbose && !index_file.empty() && n_cpgs != 0)
-    println(std::cerr, "Only one of n-cpgs and index are needed to unzip");
+  if (metadata_output.empty())
+    metadata_input = std::format("{}.json", methylome_input);
 
-  if (verbose)
-    print("Input: {}\n"
-          "Output: {}\n"
-          "Unzip: {}\n"
-          "N-CpGs: {}\n"
-          "Index: {}\n",
-          input_file, output_file, unzip, unzip ? std::to_string(n_cpgs) : "NA",
-          index_file.empty() ? "NA" : index_file);
+  if (metadata_output.empty())
+    metadata_output = std::format("{}.json", methylome_output);
 
-  if (unzip && !index_file.empty()) {
-    cpg_index index{};
-    if (const auto index_read_err = index.read(index_file); index_read_err) {
-      println(std::cerr, "Error: {} ({})", index_read_err, index_file);
-      return EXIT_FAILURE;
-    }
-    if (n_cpgs != 0 && n_cpgs != index.n_cpgs_total) {
-      println(std::cerr, "Inconsistent n-cpgs given ({} vs. {} in {})", n_cpgs,
-              index.n_cpgs_total, index_file);
-      return EXIT_FAILURE;
-    }
-    n_cpgs = index.n_cpgs_total;
+  std::vector<std::tuple<std::string, std::string>> args_to_log{
+    // clang-format off
+    {"Input", methylome_input},
+    {"Metadata input", metadata_input},
+    {"Output", methylome_output},
+    {"Metadata output", metadata_output},
+    {"Unzip", std::format("{}", unzip)},
+    // clang-format on
+  };
+  log_args<mxe_log_level::info>(args_to_log);
+
+  auto [meta, meta_read_err] = methylome_metadata::read(metadata_input);
+  if (meta_read_err) {
+    lgr.error("Error reading metadata: {} ({})", meta_read_err, metadata_input);
+    return EXIT_FAILURE;
   }
 
-  methylome m;
-  const auto meth_read_start{hr_clock::now()};
-  const auto meth_read_err = m.read(input_file, n_cpgs);
-  const auto meth_read_stop{hr_clock::now()};
+  if (unzip && !meta.is_compressed) {
+    lgr.warning("Attempting to unzip but methylome is not zipped");
+    return EXIT_FAILURE;
+  }
+
+  if (!unzip && meta.is_compressed) {
+    lgr.warning("Attempting to zip but methylome is zipped");
+    return EXIT_FAILURE;
+  }
+
+  methylome meth;
+  const auto meth_read_start = std::chrono::high_resolution_clock::now();
+  const auto meth_read_err = meth.read(methylome_input, meta);
+  const auto meth_read_stop = std::chrono::high_resolution_clock::now();
   if (meth_read_err) {
-    println(std::cerr, "Error reading input: {} ({})", input_file,
-            meth_read_err);
+    lgr.error("Error reading methylome: {} ({})", methylome_input,
+              meth_read_err);
     return EXIT_FAILURE;
   }
-  if (verbose)
-    println("Methylome read time: {}s",
+  lgr.debug("Methylome read time: {}s",
             duration(meth_read_start, meth_read_stop));
 
-  const auto meth_write_start{hr_clock::now()};
-  const auto meth_write_err = m.write(output_file, !unzip);
-  const auto meth_write_stop{hr_clock::now()};
+  const auto meth_write_start = std::chrono::high_resolution_clock::now();
+  const auto meth_write_err = meth.write(methylome_output, !unzip);
+  const auto meth_write_stop = std::chrono::high_resolution_clock::now();
   if (meth_write_err) {
-    println(std::cerr, "Error writing output: {} ({})", output_file,
-            meth_write_err);
+    lgr.error("Error writing output: {} ({})", methylome_output,
+              meth_write_err);
     return EXIT_FAILURE;
   }
-  if (verbose)
-    println("Methylome write time: {}s",
+  lgr.debug("Methylome write time: {}s",
             duration(meth_write_start, meth_write_stop));
+
+  meta.is_compressed = !meta.is_compressed;
+
+  if (const auto err = methylome_metadata::write(meta, metadata_output); err) {
+    lgr.error("Error writing metadata: {} ({})", err, metadata_output);
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Unfortunately many changes within this PR unrelated to the bins query. The bins query itself has some design issues. For example, the response header uses the same variable for different things depending on the type of request. Other issues are similar in that they are derived from using the same variables for different purposes depending on the type of query