### PR TITLE
Changing to static read functions for data with metadata

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,10 @@ add_library(logger OBJECT
   logger.hpp
   logger.cpp)
 
+add_library(hash OBJECT
+  hash.hpp
+  hash.cpp)
+
 add_library(utilities OBJECT
   utilities.hpp
   utilities.cpp)

--- a/src/command_bins.cpp
+++ b/src/command_bins.cpp
@@ -28,6 +28,7 @@
 #include "genomic_interval.hpp"
 #include "logger.hpp"
 #include "methylome.hpp"
+#include "methylome_metadata.hpp"
 #include "mxe_error.hpp"
 #include "request.hpp"
 #include "utilities.hpp"
@@ -85,8 +86,7 @@ do_local_bins(const string &meth_file, const string &meta_file,
     return {{}, meta_err};
   }
 
-  methylome meth{};
-  const auto meth_read_err = meth.read(meth_file, meta);
+  const auto [meth, meth_read_err] = methylome::read(meth_file, meta);
   if (meth_read_err) {
     logger::instance().error("Error: {} ({})", meth_read_err, meth_file);
     return {{}, meth_read_err};

--- a/src/command_check.cpp
+++ b/src/command_check.cpp
@@ -26,6 +26,7 @@
 #include "cpg_index.hpp"
 #include "logger.hpp"
 #include "methylome.hpp"
+#include "methylome_metadata.hpp"
 #include "mxe_error.hpp"
 
 #include <boost/program_options.hpp>
@@ -113,8 +114,7 @@ command_check_main(int argc, char *argv[]) -> int {
     return EXIT_FAILURE;
   }
 
-  methylome meth{};
-  const auto meth_read_err = meth.read(methylome_input, meta);
+  const auto [meth, meth_read_err] = methylome::read(methylome_input, meta);
   if (meth_read_err) {
     lgr.error("Error reading methylome {}: {}", methylome_input, meth_read_err);
     return EXIT_FAILURE;

--- a/src/command_intervals.cpp
+++ b/src/command_intervals.cpp
@@ -81,13 +81,13 @@ do_local_intervals(const string &meth_file, const string &meth_meta_file,
                    const cpg_index &index,
                    vector<methylome::offset_pair> offsets)
   -> std::tuple<vector<counts_res_type>, std::error_code> {
-  const auto [mm, meta_err] = methylome_metadata::read(meth_meta_file);
+  const auto [meta, meta_err] = methylome_metadata::read(meth_meta_file);
   if (meta_err) {
     logger::instance().error("Error: {} ({})", meta_err, meth_meta_file);
     return {{}, meta_err};
   }
-  methylome meth{};
-  if (const auto meth_err = meth.read(meth_file, mm)) {
+  const auto [meth, meth_err] = methylome::read(meth_file, meta);
+  if (meth_err) {
     logger::instance().error("Error: {} ({})", meth_err, meth_file);
     return {{}, meth_err};
   }

--- a/src/cpg_index.cpp
+++ b/src/cpg_index.cpp
@@ -364,7 +364,6 @@ cpg_index::hash() const -> std::uint64_t {
 [[nodiscard]] auto
 read_cpg_index(const std::string &index_file)
   -> std::tuple<cpg_index, cpg_index_meta, std::error_code> {
-
   const auto [ci, index_err] = cpg_index::read(index_file);
   if (index_err)
     return {cpg_index{}, cpg_index_meta{}, index_err};

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -50,8 +50,8 @@ struct cpg_index {
   typedef std::vector<cpg_pos_t> vec;
 #endif
 
-  auto
-  read(const std::string &index_file) -> std::error_code;
+  static auto
+  read(const std::string &index_file) -> std::tuple<cpg_index, std::error_code>;
   auto
   write(const std::string &index_file) const -> std::error_code;
 
@@ -78,9 +78,9 @@ struct cpg_index {
   std::vector<cpg_index::vec> positions;
 };
 
-[[nodiscard]] auto
-get_assembly_from_filename(const std::string &filename,
-                           std::error_code &ec) -> std::string;
+// [[nodiscard]] auto
+// get_assembly_from_filename(const std::string &filename,
+//                            std::error_code &ec) -> std::string;
 
 [[nodiscard]] auto
 initialize_cpg_index(const std::string &genome_file)

--- a/src/cpg_index.hpp
+++ b/src/cpg_index.hpp
@@ -55,6 +55,9 @@ struct cpg_index {
   auto
   write(const std::string &index_file) const -> std::error_code;
 
+  auto
+  hash() const -> std::uint64_t;
+
   /* ADS: currently unused */
   // [[nodiscard]] auto
   // get_offset_within_chrom(const std::int32_t ch_id,

--- a/src/cpg_index_meta.cpp
+++ b/src/cpg_index_meta.cpp
@@ -143,10 +143,10 @@ get_default_cpg_index_meta_filename(const std::string &indexfile)
 [[nodiscard]] auto
 get_assembly_from_filename(const std::string &filename,
                            std::error_code &ec) -> std::string {
-  using namespace std::literals;
+  using std::string_literals::operator""s;
+  using std::literals::string_view_literals::operator""sv;
   // clang-format off
-  const auto fasta_suff =
-    std::vector{
+  const auto fasta_suff = std::vector {
     "fa"sv,
     "fa.gz"sv,
     "faa"sv,

--- a/src/cpg_index_meta.hpp
+++ b/src/cpg_index_meta.hpp
@@ -102,12 +102,15 @@ struct cpg_index_meta {
   std::vector<std::uint32_t> chrom_size;
   std::vector<std::uint32_t> chrom_offset;
 
-  [[nodiscard]] auto
-  write(const std::string &json_filename) const -> std::error_code;
-
   [[nodiscard]] static auto
   read(const std::string &json_filename)
     -> std::tuple<cpg_index_meta, std::error_code>;
+
+  [[nodiscard]] auto
+  write(const std::string &json_filename) const -> std::error_code;
+
+  [[nodiscard]] auto
+  init_env() -> std::error_code;
 
   [[nodiscard]] auto
   tostring() const -> std::string;
@@ -144,5 +147,9 @@ struct std::formatter<cpg_index_meta> : std::formatter<std::string> {
 [[nodiscard]] auto
 get_default_cpg_index_meta_filename(const std::string &indexfile)
   -> std::string;
+
+[[nodiscard]] auto
+get_assembly_from_filename(const std::string &filename,
+                           std::error_code &ec) -> std::string;
 
 #endif  // SRC_CPG_INDEX_META_HPP_

--- a/src/cpg_index_set.hpp
+++ b/src/cpg_index_set.hpp
@@ -40,6 +40,10 @@ struct cpg_index_set {
 
   explicit cpg_index_set(const std::string &cpg_index_directory);
 
+  // [[nodiscard]] static auto
+  // read(const std::string &filename)
+  //   -> std::tuple<cpg_index_set, std::error_code>;
+
   /* ADS: currently unused */
   // [[nodiscard]] auto
   // get_cpg_index(const std::string &assembly_name)
@@ -57,7 +61,6 @@ struct cpg_index_set {
   // [[nodiscard]] auto
   // get_genome_sizes() -> std::unordered_map<std::string, std::uint64_t>;
 
-  std::string cpg_index_directory;
   std::unordered_map<std::string, cpg_index> assembly_to_cpg_index;
   std::unordered_map<std::string, cpg_index_meta> assembly_to_cpg_index_meta;
 };

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,0 +1,63 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "hash.hpp"
+
+#include <zlib.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+// ADS: this function should be replaced by one that can operate on a
+// the data as though it were serealized but without reading the file
+[[nodiscard]] auto
+get_adler(const std::string &filename) -> std::uint64_t {
+  const auto filesize = std::filesystem::file_size(filename);
+  std::vector<char> buf(filesize);
+  std::ifstream in(filename);
+  in.read(buf.data(), filesize);
+  return adler32_z(0, reinterpret_cast<std::uint8_t *>(buf.data()), filesize);
+}
+
+// ADS: this function should be replaced by one that can operate on a
+// the data as though it were serealized but without reading the file
+[[nodiscard]] auto
+get_adler(const std::string &filename, std::error_code &ec) -> std::uint64_t {
+  const auto filesize = std::filesystem::file_size(filename, ec);
+  if (ec)
+    return 0;
+  std::vector<char> buf(filesize);
+  std::ifstream in(filename);
+  if (!in) {
+    ec = std::make_error_code(std::errc(errno));
+    return 0;
+  }
+  if (!in.read(buf.data(), filesize)) {
+    ec = std::make_error_code(std::errc(errno));
+    return 0;
+  }
+  return adler32_z(0, reinterpret_cast<std::uint8_t *>(buf.data()), filesize);
+}

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -1,0 +1,48 @@
+/* MIT License
+ *
+ * Copyright (c) 2024 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_HASH_HPP_
+#define SRC_HASH_HPP_
+
+#include <zlib.h>
+
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+[[nodiscard]] inline auto
+get_adler(const auto &data, const auto data_size) -> std::uint64_t {
+  return adler32_z(0, reinterpret_cast<const std::uint8_t *>(data), data_size);
+}
+
+// ADS: this function should be replaced by one that can operate on a
+// the data as though it were serealized but without reading the file
+[[nodiscard]] auto
+get_adler(const std::string &filename) -> std::uint64_t;
+
+// ADS: this function should be replaced by one that can operate on a
+// the data as though it were serealized but without reading the file
+[[nodiscard]] auto
+get_adler(const std::string &filename, std::error_code &ec) -> std::uint64_t;
+
+#endif  // SRC_HASH_HPP_

--- a/src/methylome.hpp
+++ b/src/methylome.hpp
@@ -32,9 +32,11 @@
 #include "cpg_index_meta.hpp"
 #include "methylome_results_types.hpp"
 
-#include <cmath>  // std::round
+#include <algorithm>  // std::max
+#include <cmath>      // std::round
 #include <cstddef>
 #include <cstdint>
+#include <limits>  // std::numeric_limits<>
 #include <string>
 #include <system_error>
 #include <tuple>

--- a/src/methylome_metadata.hpp
+++ b/src/methylome_metadata.hpp
@@ -24,7 +24,8 @@
 #ifndef SRC_METHYLOME_METADATA_HPP_
 #define SRC_METHYLOME_METADATA_HPP_
 
-#include "utilities.hpp"  // get_adler
+#include "cpg_index_meta.hpp"
+#include "methylome.hpp"
 
 #include <boost/describe.hpp>  // for BOOST_DESCRIBE_STRUCT
 
@@ -87,6 +88,8 @@ make_error_code(methylome_metadata_error e) {
   return std::error_code(std::to_underlying(e), category);
 }
 
+struct methylome;
+
 struct methylome_metadata {
   static constexpr auto filename_extension{"m16.json"};
   std::string version;
@@ -100,19 +103,18 @@ struct methylome_metadata {
   bool is_compressed{};
   // ADS: (todo) think of a better way to get "compression" status
   [[nodiscard]] static auto
-  init(const std::string &index_filename, const std::string &methylome_filename,
+  init(const cpg_index_meta &cim, const methylome &meth,
        const bool is_compressed)
     -> std::tuple<methylome_metadata, std::error_code>;
   [[nodiscard]] static auto
   read(const std::string &json_filename)
     -> std::tuple<methylome_metadata, std::error_code>;
-  [[nodiscard]] static auto
-  write(const methylome_metadata &mm,
-        const std::string &json_filename) -> std::error_code;
+  [[nodiscard]] auto
+  write(const std::string &json_filename) const -> std::error_code;
   [[nodiscard]] auto
   tostring() const -> std::string;
   [[nodiscard]] auto
-  update(const std::string &methylome_filename) -> std::error_code;
+  update(const methylome &meth) -> std::error_code;
 };
 
 // clang-format off

--- a/src/methylome_set.cpp
+++ b/src/methylome_set.cpp
@@ -103,8 +103,8 @@ methylome_set::get_methylome(const std::string &accession)
               methylome_set_code::error_reading_methylome_file};
 
     // ADS: get an error code from methylome::read and use it
-    methylome m{};
-    if ([[maybe_unused]] const auto ec = m.read(methylome_filename, mm))
+    const auto [m, ec] = methylome::read(methylome_filename, mm);
+    if (ec)
       return {nullptr, nullptr,
               methylome_set_code::error_reading_methylome_file};
 


### PR DESCRIPTION
The pattern is to construct raw data first, then use it to create metadata, then write in that order. On read, the metadata is read first, and then used to read raw data