### PR TITLE
Iterative reads in client for robustness to timeouts

### DIFF
--- a/src/command_bins.cpp
+++ b/src/command_bins.cpp
@@ -64,8 +64,7 @@ do_remote_bins(const string &accession, const cpg_index_meta &cim,
     hdr.rq_type = request_header::request_type::bin_counts_cov;
 
   bins_request req{bin_size};
-  mxe_client<counts_res_type, bins_request> mxec(hostname, port, hdr, req,
-                                                 logger::instance());
+  mxe_client<counts_res_type, bins_request> mxec(hostname, port, hdr, req);
   const auto status = mxec.run();
   if (status) {
     logger::instance().error("Transaction status: {}", status);

--- a/src/command_intervals.cpp
+++ b/src/command_intervals.cpp
@@ -65,8 +65,7 @@ do_remote_intervals(const string &accession, const cpg_index_meta &cim,
     hdr.rq_type = request_header::request_type::counts_cov;
 
   request req{static_cast<std::uint32_t>(size(offsets)), offsets};
-  mxe_client<counts_res_type, request> mxec(hostname, port, hdr, req,
-                                            logger::instance());
+  mxe_client<counts_res_type, request> mxec(hostname, port, hdr, req);
   const auto status = mxec.run();
   if (status) {
     logger::instance().error("Transaction status: {}", status);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -62,6 +62,7 @@ connection::read_request() -> void {
                     from_chars(req_hdr_parse.ptr, cend(req_hdr_buf), req);
                   !req_parse.error) {
                 prepare_to_read_offsets();
+                handler.add_response_size_for_intervals(req_hdr, req, resp_hdr);
                 read_offsets();
               }
               else {

--- a/src/request_handler.cpp
+++ b/src/request_handler.cpp
@@ -78,6 +78,13 @@ request_handler::add_response_size_for_bins(const request_header &req_hdr,
   resp_hdr.response_size = cim.get_n_bins(req.bin_size);
 }
 
+auto
+request_handler::add_response_size_for_intervals(
+  [[maybe_unused]] const request_header &req_hdr, const request &req,
+  response_header &resp_hdr) -> void {
+  resp_hdr.response_size = req.n_intervals;
+}
+
 // ADS: This function needs a complete request *except* it does not
 // need the offsets to have been allocated or have any values read
 // into them.

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -62,6 +62,11 @@ struct request_handler {
                              const bins_request &req,
                              response_header &resp_hdr) -> void;
 
+  auto
+  add_response_size_for_intervals(
+    [[maybe_unused]] const request_header &req_hdr, const request &req,
+    response_header &resp_hdr) -> void;
+
   std::string methylome_dir;   // dir of available methylomes
   std::string index_file_dir;  // dir of cpg index files
   methylome_set ms;


### PR DESCRIPTION
Now the client is using async_read_some and the timeout applies for each call to async_read_some; this will hopefully allow for a small deadline to not be violated as long as data keeps coming